### PR TITLE
feat: v1.2.0 — Device Compliance, Exchange, Intune Scripts, async and CIM fixes

### DIFF
--- a/LazyWinAdminModule/Classes/ApplicationState.ps1
+++ b/LazyWinAdminModule/Classes/ApplicationState.ps1
@@ -13,11 +13,18 @@ class LazyWinAdminState {
 
     LazyWinAdminState() {
         $this.SyncHash = [hashtable]::Synchronized(@{})
-        $this.SyncHash.Logs           = [System.Collections.ArrayList]::new()
-        $this.SyncHash.IsBusy         = $false
+        $this.SyncHash.Logs             = [System.Collections.ArrayList]::new()
+        $this.SyncHash.IsBusy           = $false
         # Set to $true by the cloud-auth OnCompleted handler once [OK] is returned.
         # Read by $RequireCloudSession guard in button handlers before dispatching async work.
-        $this.SyncHash.CloudConnected = $false
+        $this.SyncHash.CloudConnected   = $false
+        # Set to $true by the Exchange OnCompleted handler after a successful connection.
+        # Read by $RequireExchangeSession guard.
+        $this.SyncHash.ExchangeConnected = $false
+        # Thread-safe queue drained by the DispatcherTimer on the WPF UI thread.
+        # Register-ObjectEvent actions enqueue completed job results here instead of
+        # calling Dispatcher.InvokeAsync, avoiding all cross-thread delegate issues.
+        $this.SyncHash.UIQueue          = [System.Collections.Concurrent.ConcurrentQueue[object]]::new()
 
         $this.CimSessions = [hashtable]::Synchronized(@{})
 

--- a/LazyWinAdminModule/LazyWinAdminModule.psd1
+++ b/LazyWinAdminModule/LazyWinAdminModule.psd1
@@ -1,11 +1,11 @@
 @{
     RootModule        = 'LazyWinAdminModule.psm1'
-    ModuleVersion     = '1.1.0'
+    ModuleVersion     = '1.2.0'
     GUID              = '1b9e5d4a-5c20-4e3a-b892-0b13d2f9a1c2'
     Author            = 'Francois-Xavier Cat (Modernized)'
     CompanyName       = 'LazyWinAdmin'
     Copyright         = '(c) LazyWinAdmin. All rights reserved.'
-    Description       = 'Modernized LazyWinAdmin GUI Module — 2026 Edition'
+    Description       = 'Modernized LazyWinAdmin GUI Module — 2026 Edition (v1.2.0)'
 
     # Minimum PS version per DEPS.SYSTEM in lazywinadmin.speq
     PowerShellVersion = '7.4'

--- a/LazyWinAdminModule/Private/Connect-ExchangeSession.ps1
+++ b/LazyWinAdminModule/Private/Connect-ExchangeSession.ps1
@@ -6,6 +6,12 @@ function Connect-ExchangeSession {
         Checks for the ExchangeOnlineManagement module, imports it, and initiates
         an interactive connection. Returns a status string — never surfaces
         exception detail or credential fragments to the caller.
+    .PARAMETER UserPrincipalName
+        Optional UPN (e.g. 'admin@contoso.com') used to pre-fill the sign-in dialog.
+        When omitted, the user is prompted to enter credentials interactively.
+    .OUTPUTS
+        System.String — starts with '[OK]' followed by the organisation display name
+        on success, or '[!]' with an error description on failure.
     #>
     [CmdletBinding()]
     param (

--- a/LazyWinAdminModule/Private/Connect-ExchangeSession.ps1
+++ b/LazyWinAdminModule/Private/Connect-ExchangeSession.ps1
@@ -1,0 +1,34 @@
+function Connect-ExchangeSession {
+    <#
+    .SYNOPSIS
+        Connects to Exchange Online using modern authentication.
+    .DESCRIPTION
+        Checks for the ExchangeOnlineManagement module, imports it, and initiates
+        an interactive connection. Returns a status string — never surfaces
+        exception detail or credential fragments to the caller.
+    #>
+    [CmdletBinding()]
+    param (
+        [string]$UserPrincipalName
+    )
+
+    try {
+        if (-not (Get-Module -Name ExchangeOnlineManagement -ListAvailable)) {
+            return "[!] ExchangeOnlineManagement module not found. Install with: Install-Module ExchangeOnlineManagement -Scope CurrentUser"
+        }
+
+        Import-Module ExchangeOnlineManagement -ErrorAction Stop
+
+        $params = @{ ShowBanner = $false; ErrorAction = 'Stop' }
+        if ($UserPrincipalName) { $params.UserPrincipalName = $UserPrincipalName }
+
+        Connect-ExchangeOnline @params
+
+        $org = Get-OrganizationConfig -ErrorAction Stop
+        return "[OK] Connected to Exchange Online: $($org.DisplayName)"
+    }
+    catch {
+        Write-Verbose "Exchange connection exception: $_"
+        return "[!] Connection failed. Verify the ExchangeOnlineManagement module is installed and credentials are correct."
+    }
+}

--- a/LazyWinAdminModule/Private/Connect-ModernCloud.ps1
+++ b/LazyWinAdminModule/Private/Connect-ModernCloud.ps1
@@ -18,7 +18,7 @@ function Connect-ModernCloud {
     try {
         if ($Interactive) {
             Write-Verbose "Triggering interactive login..."
-            Connect-MgGraph -Scopes "User.ReadBasic.All", "Group.Read.All", "DeviceManagementManagedDevices.Read.All"
+            Connect-MgGraph -Scopes "User.ReadBasic.All", "Group.Read.All", "DeviceManagementManagedDevices.Read.All", "DeviceManagementConfiguration.Read.All"
         }
         elseif ($ClientId -and $ClientSecret) {
             Write-Verbose "Connecting via Service Principal..."

--- a/LazyWinAdminModule/Private/Connect-ModernCloud.ps1
+++ b/LazyWinAdminModule/Private/Connect-ModernCloud.ps1
@@ -2,6 +2,47 @@ function Connect-ModernCloud {
     <#
     .SYNOPSIS
         Connects to Microsoft Graph / Entra ID using modern authentication.
+    .DESCRIPTION
+        Supports two authentication modes:
+
+        Interactive (-Interactive switch): Opens a browser-based interactive sign-in
+        and requests the scopes required by LazyWinAdmin (User.ReadBasic.All,
+        Group.Read.All, DeviceManagementManagedDevices.Read.All,
+        DeviceManagementConfiguration.Read.All).
+
+        Service Principal (-ClientId / -ClientSecret / -TenantId): Authenticates
+        non-interactively using an Entra app registration credential.
+        TenantId must be a GUID or an onmicrosoft.com domain name.
+
+        The two modes are mutually exclusive. Using both in the same call is an error.
+        Returns a status string prefixed with [OK] on success or [!] on failure.
+        Exception detail and credential fragments are never included in the return value
+        — they are written to the Verbose stream only.
+    .PARAMETER TenantId
+        Entra tenant identifier. Required for service principal mode.
+        Must be a GUID (e.g. '00000000-0000-0000-0000-000000000000') or an
+        onmicrosoft.com domain name (e.g. 'contoso.onmicrosoft.com').
+        Not used in interactive mode.
+    .PARAMETER ClientId
+        Application (client) ID of the Entra app registration.
+        Required for service principal mode, mutually exclusive with -Interactive.
+    .PARAMETER ClientSecret
+        Client secret for the app registration, provided as a SecureString.
+        Required for service principal mode, mutually exclusive with -Interactive.
+    .PARAMETER Interactive
+        When specified, triggers a browser-based interactive sign-in.
+        Mutually exclusive with -ClientId / -ClientSecret.
+    .OUTPUTS
+        System.String — starts with '[OK]' on success or '[!]' on failure/validation error.
+    .EXAMPLE
+        # Interactive sign-in
+        Connect-ModernCloud -Interactive
+    .EXAMPLE
+        # Service principal sign-in
+        $secret = Read-Host -AsSecureString 'Client Secret'
+        Connect-ModernCloud -TenantId 'contoso.onmicrosoft.com' `
+                            -ClientId '00000000-0000-0000-0000-000000000000' `
+                            -ClientSecret $secret
     #>
     [CmdletBinding()]
     param (
@@ -16,6 +57,16 @@ function Connect-ModernCloud {
     )
 
     try {
+        if ($Interactive -and ($ClientId -or $ClientSecret)) {
+            return "[!] Specify either -Interactive or -ClientId/-ClientSecret, not both."
+        }
+        if (-not $Interactive -and (-not $ClientId -or -not $ClientSecret -or -not $TenantId)) {
+            return "[!] Service principal mode requires -TenantId, -ClientId, and -ClientSecret."
+        }
+        if (-not $Interactive -and $TenantId -notmatch '^[a-fA-F0-9\-]{36}$|^[\w\-]+\.onmicrosoft\.com$') {
+            return "[!] TenantId must be a GUID or an onmicrosoft.com domain name."
+        }
+
         if ($Interactive) {
             Write-Verbose "Triggering interactive login..."
             Connect-MgGraph -Scopes "User.ReadBasic.All", "Group.Read.All", "DeviceManagementManagedDevices.Read.All", "DeviceManagementConfiguration.Read.All"
@@ -24,8 +75,8 @@ function Connect-ModernCloud {
             Write-Verbose "Connecting via Service Principal..."
             $credential = [System.Management.Automation.PSCredential]::new($ClientId, $ClientSecret)
             $body = @{
-                TenantId              = $TenantId
-                ClientId              = $ClientId
+                TenantId               = $TenantId
+                ClientId               = $ClientId
                 ClientSecretCredential = $credential
             }
             Connect-MgGraph @body

--- a/LazyWinAdminModule/Private/Get-AzureResourceSummary.ps1
+++ b/LazyWinAdminModule/Private/Get-AzureResourceSummary.ps1
@@ -6,6 +6,11 @@ function Get-AzureResourceSummary {
         Uses Search-AzGraph (Az.ResourceGraph) for server-side aggregation.
         Avoids Get-AzResource which enumerates all resources client-side and does not scale.
         Requires Az.ResourceGraph module (included in Az).
+    .OUTPUTS
+        System.Object[] — array of PSCustomObject with properties:
+          Name  (System.String)  — Azure resource type, e.g. 'microsoft.compute/virtualmachines'.
+          Count (System.Int64)   — number of resources of that type in the subscription.
+        Returns $null when not connected to Azure or when an error occurs.
     #>
     [CmdletBinding()]
     param ()

--- a/LazyWinAdminModule/Private/Get-ComputerADInfo.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerADInfo.ps1
@@ -7,6 +7,34 @@ function Get-ComputerADInfo {
         running this function. Validates AdFilter input before passing to AD cmdlets.
         Adheres to: ad_computer.* REQUIRES rsat-ad-module (CONTRACTS)
                     ad_user.samaccountname NEVER logged (CLASSIFY: pii)
+    .OUTPUTS
+        Type=Computer — System.Object[] of AD computer objects with properties:
+          Name, DNSHostName, OperatingSystem, OperatingSystemVersion,
+          LastLogonDate, Enabled, Description, DistinguishedName.
+
+        Type=User — System.Object[] of AD user objects with properties:
+          DisplayName, EmailAddress, Department, Title, LastLogonDate,
+          Enabled, DistinguishedName.
+          Note: SamAccountName is intentionally excluded to prevent accidental
+          PII logging in the UI layer.
+
+        Type=Group — System.Object[] of AD group objects with properties:
+          Name, SamAccountName, GroupCategory, GroupScope, Description.
+
+        Returns $null when the ActiveDirectory module is not available, the AdFilter
+        contains invalid characters, or an error occurs.
+    .EXAMPLE
+        # List all computers whose name starts with 'WS-'
+        Get-ComputerADInfo -Type Computer -AdFilter 'WS-*'
+    .EXAMPLE
+        # Find a specific computer by exact name
+        Get-ComputerADInfo -Type Computer -ComputerName 'WS-001'
+    .EXAMPLE
+        # Search for users whose display name or SAM starts with 'john'
+        Get-ComputerADInfo -Type User -AdFilter 'john*'
+    .EXAMPLE
+        # List all AD groups whose name starts with 'IT'
+        Get-ComputerADInfo -Type Group -AdFilter 'IT*'
     #>
     [CmdletBinding()]
     param (

--- a/LazyWinAdminModule/Private/Get-ComputerHardware.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerHardware.ps1
@@ -1,10 +1,55 @@
 function Get-ComputerHardware {
     <#
     .SYNOPSIS
-        Retrieves hardware information (System, CPU, RAM, Disks) from a remote computer.
+        Retrieves hardware information (System, CPU, RAM, Disks) from a local or remote computer.
+
     .DESCRIPTION
         Opens a single CimSession and reuses it for all queries within the call.
         Adheres to: cim_session.* ALWAYS reuse-before-create (CONTRACTS)
+
+        The following CIM classes are queried over the shared session:
+            Win32_ComputerSystem   — model, manufacturer
+            Win32_OperatingSystem  — OS caption and version
+            Win32_Bios             — serial number
+            Win32_Processor        — CPU name and core count (one object per socket)
+            Win32_PhysicalMemory   — installed RAM sticks; capacities summed to total GB
+            Win32_LogicalDisk      — fixed local drives (DriveType = 3) with size/free space
+
+        RAM is converted from bytes to GB using the [Math]::Round(..., 2) overload, so
+        the result is always rounded to two decimal places.
+        Disk percentages are likewise rounded to two decimal places.
+
+    .PARAMETER ComputerName
+        The hostname or IP address of the target computer. This parameter is mandatory
+        because the function is typically called from a dispatcher that always supplies
+        the target explicitly.
+
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject
+        A single object with the following properties:
+            Model        [string]   — from Win32_ComputerSystem.Model
+            Manufacturer [string]   — from Win32_ComputerSystem.Manufacturer
+            RAM_GB       [double]   — total installed RAM in gigabytes, rounded to 2 d.p.
+            CPU          [string]   — comma-separated list of "<Name> (<Cores> Cores)" per socket
+            OS           [string]   — from Win32_OperatingSystem.Caption
+            OS_Version   [string]   — from Win32_OperatingSystem.Version
+            SerialNumber [string]   — from Win32_Bios.SerialNumber
+            Disks        [PSCustomObject[]] — one entry per fixed drive, each with:
+                             DeviceID, SizeGB, FreeGB, PercentFree
+        Returns $null if any CIM query fails.
+
+    .EXAMPLE
+        Get-ComputerHardware -ComputerName "localhost"
+        Returns hardware details for the local machine.
+
+    .EXAMPLE
+        Get-ComputerHardware -ComputerName "SERVER01"
+        Returns hardware details for SERVER01.
+
+    .EXAMPLE
+        $hw = Get-ComputerHardware -ComputerName "SERVER01"
+        $hw.Disks | Where-Object PercentFree -lt 10
+        Retrieves hardware info and then filters for disks with less than 10% free space.
     #>
     [CmdletBinding()]
     param (
@@ -29,6 +74,7 @@ function Get-ComputerHardware {
             $totalRamBytes = ($mem | Measure-Object -Property Capacity -Sum).Sum
             $totalRamGB    = [Math]::Round($totalRamBytes / 1GB, 2)
 
+            # DriveType 3 = local fixed disk; excludes removable, network, CD-ROM, and RAM drives
             $disks = Get-CimInstance -CimSession $CimSession -ClassName Win32_LogicalDisk `
                         -Filter "DriveType=3" -ErrorAction Stop
 

--- a/LazyWinAdminModule/Private/Get-ComputerHardware.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerHardware.ps1
@@ -15,7 +15,8 @@ function Get-ComputerHardware {
     process {
         $CimSession = $null
         try {
-            $CimSession = New-CimSession -ComputerName $ComputerName -ErrorAction Stop
+            $isLocal    = $ComputerName -iin @('localhost', '127.0.0.1', $env:COMPUTERNAME)
+            $CimSession = if ($isLocal) { New-CimSession -ErrorAction Stop } else { New-CimSession -ComputerName $ComputerName -ErrorAction Stop }
 
             $cs   = Get-CimInstance -CimSession $CimSession -ClassName Win32_ComputerSystem    -ErrorAction Stop
             $os   = Get-CimInstance -CimSession $CimSession -ClassName Win32_OperatingSystem   -ErrorAction Stop

--- a/LazyWinAdminModule/Private/Get-ComputerLocalGroup.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerLocalGroup.ps1
@@ -1,7 +1,39 @@
 function Get-ComputerLocalGroup {
     <#
     .SYNOPSIS
-        Retrieves local groups from a remote computer using CIM.
+        Retrieves local security groups from a local or remote computer using CIM.
+
+    .DESCRIPTION
+        Queries the Win32_Group CIM class with a filter of LocalAccount = True
+        so that domain groups mirrored into the local SAM are excluded. Only
+        groups that are native to the target machine are returned.
+
+        When ComputerName resolves to the local machine (localhost, 127.0.0.1,
+        or $env:COMPUTERNAME) no CIM ComputerName parameter is sent, avoiding
+        an unnecessary remote-protocol hop.
+
+    .PARAMETER ComputerName
+        The hostname or IP address of the target computer.
+        Defaults to "localhost" (the local machine).
+        Accepts pipeline input.
+
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject[]
+        An array of selected Win32_Group objects with the following properties:
+            Name, Caption, SID, Status
+        Returns $null if the query fails.
+
+    .EXAMPLE
+        Get-ComputerLocalGroup
+        Returns all local security groups on the local machine.
+
+    .EXAMPLE
+        Get-ComputerLocalGroup -ComputerName "WORKSTATION42"
+        Returns all local security groups on WORKSTATION42.
+
+    .EXAMPLE
+        "SERVER01","SERVER02" | Get-ComputerLocalGroup
+        Returns local security groups for each computer in the pipeline.
     #>
     [CmdletBinding()]
     param (

--- a/LazyWinAdminModule/Private/Get-ComputerLocalGroup.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerLocalGroup.ps1
@@ -11,7 +11,10 @@ function Get-ComputerLocalGroup {
 
     process {
         try {
-            $groups = Get-CimInstance -ClassName Win32_Group -Filter "LocalAccount = True" -ComputerName $ComputerName -ErrorAction Stop
+            $isLocal   = $ComputerName -iin @('localhost', '127.0.0.1', $env:COMPUTERNAME)
+            $cimParams = @{ ClassName = "Win32_Group"; Filter = "LocalAccount = True"; ErrorAction = "Stop" }
+            if (-not $isLocal) { $cimParams.ComputerName = $ComputerName }
+            $groups = Get-CimInstance @cimParams
             return $groups | Select-Object Name, Caption, SID, Status
         }
         catch {

--- a/LazyWinAdminModule/Private/Get-ComputerLocalUser.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerLocalUser.ps1
@@ -11,7 +11,10 @@ function Get-ComputerLocalUser {
 
     process {
         try {
-            $users = Get-CimInstance -ClassName Win32_UserAccount -Filter "LocalAccount = True" -ComputerName $ComputerName -ErrorAction Stop
+            $isLocal   = $ComputerName -iin @('localhost', '127.0.0.1', $env:COMPUTERNAME)
+            $cimParams = @{ ClassName = "Win32_UserAccount"; Filter = "LocalAccount = True"; ErrorAction = "Stop" }
+            if (-not $isLocal) { $cimParams.ComputerName = $ComputerName }
+            $users = Get-CimInstance @cimParams
             return $users | Select-Object Name, FullName, Disabled, Lockout, PasswordRequired, PasswordExpires, SID, Status
         }
         catch {

--- a/LazyWinAdminModule/Private/Get-ComputerLocalUser.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerLocalUser.ps1
@@ -1,7 +1,45 @@
 function Get-ComputerLocalUser {
     <#
     .SYNOPSIS
-        Retrieves local user accounts from a remote computer using CIM.
+        Retrieves local user accounts from a local or remote computer using CIM.
+
+    .DESCRIPTION
+        Queries the Win32_UserAccount CIM class with a filter of LocalAccount = True
+        so that domain accounts mirrored into the local SAM are excluded.
+
+        The Password property is intentionally omitted from the returned objects.
+        Even though Win32_UserAccount does not expose the actual password hash,
+        excluding it makes the security boundary explicit and prevents any future
+        CIM class changes from accidentally surfacing credential material.
+
+        When ComputerName resolves to the local machine (localhost, 127.0.0.1,
+        or $env:COMPUTERNAME) no CIM ComputerName parameter is sent, avoiding
+        an unnecessary remote-protocol hop.
+
+    .PARAMETER ComputerName
+        The hostname or IP address of the target computer.
+        Defaults to "localhost" (the local machine).
+        Accepts pipeline input.
+
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject[]
+        An array of selected Win32_UserAccount objects with the following properties:
+            Name, FullName, Disabled, Lockout, PasswordRequired, PasswordExpires,
+            SID, Status
+        The Password property is intentionally excluded for security.
+        Returns $null if the query fails.
+
+    .EXAMPLE
+        Get-ComputerLocalUser
+        Returns all local user accounts on the local machine.
+
+    .EXAMPLE
+        Get-ComputerLocalUser -ComputerName "WORKSTATION42"
+        Returns all local user accounts on WORKSTATION42.
+
+    .EXAMPLE
+        "SERVER01","SERVER02" | Get-ComputerLocalUser
+        Returns local user accounts for each computer in the pipeline.
     #>
     [CmdletBinding()]
     param (

--- a/LazyWinAdminModule/Private/Get-ComputerMotherboard.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerMotherboard.ps1
@@ -15,7 +15,8 @@ function Get-ComputerMotherboard {
     process {
         $CimSession = $null
         try {
-            $CimSession  = New-CimSession -ComputerName $ComputerName -ErrorAction Stop
+            $isLocal    = $ComputerName -iin @('localhost', '127.0.0.1', $env:COMPUTERNAME)
+            $CimSession = if ($isLocal) { New-CimSession -ErrorAction Stop } else { New-CimSession -ComputerName $ComputerName -ErrorAction Stop }
             $baseBoard   = Get-CimInstance -CimSession $CimSession -ClassName Win32_BaseBoard -ErrorAction Stop
 
             return [PSCustomObject]@{

--- a/LazyWinAdminModule/Private/Get-ComputerMotherboard.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerMotherboard.ps1
@@ -1,10 +1,43 @@
 function Get-ComputerMotherboard {
     <#
     .SYNOPSIS
-        Retrieves motherboard information from a remote computer using CIM.
+        Retrieves motherboard (baseboard) information from a local or remote computer using CIM.
+
     .DESCRIPTION
         Opens a single CimSession and closes it in the finally block.
         Adheres to: cim_session.* ALWAYS reuse-before-create (CONTRACTS)
+
+        Queries Win32_BaseBoard via the shared CimSession and returns a lightweight
+        PSCustomObject containing the four most operationally relevant properties.
+        The SerialNumber field is particularly useful for asset-management workflows
+        where the chassis serial number (from Win32_Bios) differs from the board serial.
+
+    .PARAMETER ComputerName
+        The hostname or IP address of the target computer. This parameter is mandatory
+        because the function is typically called from a dispatcher that always supplies
+        the target explicitly.
+
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject
+        A single object with the following properties sourced from Win32_BaseBoard:
+            Product      [string] — board product name / model identifier
+            Manufacturer [string] — board manufacturer name
+            SerialNumber [string] — board serial number (may differ from chassis serial)
+            Version      [string] — board version / revision string
+        Returns $null if the CIM query fails.
+
+    .EXAMPLE
+        Get-ComputerMotherboard -ComputerName "localhost"
+        Returns motherboard details for the local machine.
+
+    .EXAMPLE
+        Get-ComputerMotherboard -ComputerName "WORKSTATION42"
+        Returns motherboard details for WORKSTATION42.
+
+    .EXAMPLE
+        $board = Get-ComputerMotherboard -ComputerName "SERVER01"
+        "$($board.Manufacturer) $($board.Product) — S/N: $($board.SerialNumber)"
+        Formats a one-line summary of the board identity.
     #>
     [CmdletBinding()]
     param (

--- a/LazyWinAdminModule/Private/Get-ComputerNetwork.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerNetwork.ps1
@@ -17,7 +17,8 @@ function Get-ComputerNetwork {
     process {
         $CimSession = $null
         try {
-            $CimSession = New-CimSession -ComputerName $ComputerName -ErrorAction Stop
+            $isLocal    = $ComputerName -iin @('localhost', '127.0.0.1', $env:COMPUTERNAME)
+            $CimSession = if ($isLocal) { New-CimSession -ErrorAction Stop } else { New-CimSession -ComputerName $ComputerName -ErrorAction Stop }
 
             $filter   = if ($OnlyIPEnabled) { "IPEnabled = True" } else { $null }
             $adapters = Get-CimInstance -CimSession $CimSession -ClassName Win32_NetworkAdapterConfiguration `

--- a/LazyWinAdminModule/Private/Get-ComputerNetwork.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerNetwork.ps1
@@ -1,10 +1,55 @@
 function Get-ComputerNetwork {
     <#
     .SYNOPSIS
-        Retrieves network adapter configuration from a remote computer using CIM.
+        Retrieves network adapter configuration from a local or remote computer using CIM.
+
     .DESCRIPTION
         Opens a single CimSession and closes it in the finally block.
         Adheres to: cim_session.* ALWAYS reuse-before-create (CONTRACTS)
+
+        Queries Win32_NetworkAdapterConfiguration for all adapters, or only those
+        with IP enabled when -OnlyIPEnabled is specified. Multi-valued properties
+        (IPAddress, IPSubnet, DefaultIPGateway) are joined into comma-separated
+        strings so that the output objects are easily displayable in a grid or table.
+
+        Results are sorted alphabetically by Description so that the presentation
+        order is stable across successive calls.
+
+    .PARAMETER ComputerName
+        The hostname or IP address of the target computer. This parameter is mandatory
+        because the function is typically called from a dispatcher that always supplies
+        the target explicitly.
+
+    .PARAMETER OnlyIPEnabled
+        When set, the CIM query is filtered to Win32_NetworkAdapterConfiguration
+        instances where IPEnabled = True. This excludes virtual adapters,
+        loopback adapters, and other interfaces that have no bound IP stack.
+
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject[]
+        An array of adapter objects sorted by Description, each with the following
+        properties:
+            Description      [string]  — adapter name / friendly description
+            IPAddress        [string]  — comma-separated list of assigned IP addresses
+            IPSubnet         [string]  — comma-separated list of subnet masks
+            DefaultIPGateway [string]  — comma-separated list of gateway addresses
+            MACAddress       [string]  — hardware MAC address
+            DHCPEnabled      [bool]    — whether DHCP is active on this adapter
+            DHCPServer       [string]  — DHCP server address (if applicable)
+            DNSHostName      [string]  — DNS hostname registered by this adapter
+        Returns $null if the CIM query fails.
+
+    .EXAMPLE
+        Get-ComputerNetwork -ComputerName "localhost"
+        Returns all network adapter configurations on the local machine.
+
+    .EXAMPLE
+        Get-ComputerNetwork -ComputerName "SERVER01" -OnlyIPEnabled
+        Returns only IP-enabled adapters on SERVER01.
+
+    .EXAMPLE
+        Get-ComputerNetwork -ComputerName "SERVER01" | Where-Object DHCPEnabled -eq $false
+        Returns adapters that are statically configured on SERVER01.
     #>
     [CmdletBinding()]
     param (

--- a/LazyWinAdminModule/Private/Get-ComputerRegistryValue.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerRegistryValue.ps1
@@ -1,7 +1,36 @@
 function Get-ComputerRegistryValue {
     <#
     .SYNOPSIS
-        Retrieves a registry value from a remote computer using CIM (WMI over WinRM).
+        Reads a single string registry value from a local or remote computer via CIM/StdRegProv.
+    .DESCRIPTION
+        Uses the StdRegProv CIM class (root\default namespace) to retrieve a string registry
+        value without requiring direct registry access or WinRM for localhost.
+
+        For localhost ($ComputerName matches 'localhost', '127.0.0.1', or $env:COMPUTERNAME),
+        the CIM instance is obtained locally to avoid an unnecessary WinRM round-trip.
+        For remote targets, the CIM instance is created with -ComputerName so the call routes
+        through DCOM/WinRM as appropriate.
+
+        This function reads string values only (GetStringValue). It is intentionally limited to
+        read-only string access; use Invoke-ComputerRegistry for write operations or for reading
+        DWORD/QWord values.
+
+        Avoids Win32_Product and Get-ItemProperty so it is safe on locked-down or remote hosts.
+    .PARAMETER ComputerName
+        Hostname or IP address of the target computer. Use 'localhost' or '.' for the local machine.
+    .PARAMETER Hive
+        Registry hive abbreviation. Valid values: HKLM, HKU, HKCU, HKCR, HKCC.
+    .PARAMETER KeyPath
+        Registry key path relative to the hive root, e.g. 'SOFTWARE\Microsoft\Windows NT\CurrentVersion'.
+    .PARAMETER ValueName
+        Name of the string value to retrieve. Pass an empty string or omit to read the default value.
+    .OUTPUTS
+        System.String — the string value stored at the specified key/value, or $null if the value
+        does not exist, the key cannot be found, or an error occurs.
+    .EXAMPLE
+        Get-ComputerRegistryValue -ComputerName 'localhost' -Hive HKLM `
+            -KeyPath 'SOFTWARE\Microsoft\Windows NT\CurrentVersion' -ValueName 'ProductName'
+        # Returns e.g. 'Windows 11 Enterprise'
     #>
     [CmdletBinding()]
     param (
@@ -29,16 +58,21 @@ function Get-ComputerRegistryValue {
             }
 
             $hDefKey = $hives[$Hive]
-            
+
             # Use CIM to call StdRegProv methods (Firewall friendly)
             $params = @{
-                hDefKey = $hDefKey
+                hDefKey     = $hDefKey
                 sSubKeyName = $KeyPath
-                sValueName = $ValueName
+                sValueName  = $ValueName
             }
 
-            $result = Invoke-CimMethod -ComputerName $ComputerName -Namespace "root\default" -ClassName "StdRegProv" -MethodName "GetStringValue" -Arguments $params -ErrorAction Stop
-            
+            $isLocal   = $ComputerName -iin @('localhost', '127.0.0.1', $env:COMPUTERNAME)
+            $cimParams = @{ Namespace = "root\default"; ClassName = "StdRegProv"; ErrorAction = "Stop" }
+            if (-not $isLocal) { $cimParams.ComputerName = $ComputerName }
+            $reg = Get-CimInstance @cimParams
+
+            $result = Invoke-CimMethod -InputObject $reg -MethodName "GetStringValue" -Arguments $params -ErrorAction Stop
+
             if ($result.ReturnValue -eq 0) {
                 return $result.sValue
             }

--- a/LazyWinAdminModule/Private/Get-ComputerService.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerService.ps1
@@ -1,7 +1,59 @@
 function Get-ComputerService {
     <#
     .SYNOPSIS
-        Retrieves service information from a remote computer using CIM.
+        Retrieves service information from a local or remote computer using CIM.
+
+    .DESCRIPTION
+        Queries the Win32_Service CIM class to return a filtered view of services.
+        When ComputerName resolves to the local machine (localhost, 127.0.0.1, or
+        $env:COMPUTERNAME) no CIM ComputerName parameter is sent, avoiding an
+        unnecessary DCOM/WSMan hop.
+
+        Filtering priority:
+          1. If -Name is supplied, only the named service is returned.
+          2. Else if -OnlyAutoStopped is set, only services whose StartMode is
+             'Auto' and current State is not 'Running' are returned.
+          3. If neither switch is provided, all services are returned.
+
+        Note: -Name and -OnlyAutoStopped are mutually exclusive by convention;
+        -Name takes precedence when both are specified.
+
+    .PARAMETER ComputerName
+        The hostname or IP address of the target computer.
+        Defaults to "localhost" (the local machine).
+        Accepts pipeline input.
+
+    .PARAMETER Name
+        Optional. The exact Win32_Service.Name of a single service to retrieve.
+        When supplied, the -OnlyAutoStopped switch is ignored.
+
+    .PARAMETER OnlyAutoStopped
+        When set, restricts results to services that are configured to start
+        automatically (StartMode = 'Auto') but are not currently running
+        (State != 'Running'). Useful for identifying services that should be
+        running but have stopped unexpectedly.
+
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject[]
+        An array of selected Win32_Service objects with the following properties:
+            Name, DisplayName, State, StartMode, StartName, ProcessId
+        Returns $null if the query fails.
+
+    .EXAMPLE
+        Get-ComputerService
+        Returns all services on the local machine.
+
+    .EXAMPLE
+        Get-ComputerService -ComputerName "SERVER01" -OnlyAutoStopped
+        Returns all automatic-start services that are not running on SERVER01.
+
+    .EXAMPLE
+        Get-ComputerService -ComputerName "SERVER01" -Name "wuauserv"
+        Returns details for the Windows Update service on SERVER01.
+
+    .EXAMPLE
+        "SERVER01","SERVER02" | Get-ComputerService -OnlyAutoStopped
+        Pipes multiple computer names and returns stopped auto-start services for each.
     #>
     [CmdletBinding()]
     param (
@@ -33,7 +85,7 @@ function Get-ComputerService {
             if (-not $isLocal) { $params.ComputerName = $ComputerName }
 
             $services = Get-CimInstance @params
-            
+
             return $services | Select-Object Name, DisplayName, State, StartMode, StartName, ProcessId
         }
         catch {

--- a/LazyWinAdminModule/Private/Get-ComputerService.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerService.ps1
@@ -15,6 +15,8 @@ function Get-ComputerService {
 
     process {
         try {
+            $isLocal = $ComputerName -iin @('localhost', '127.0.0.1', $env:COMPUTERNAME)
+
             $filter = ""
             if ($Name) {
                 $filter = "Name = '$Name'"
@@ -24,11 +26,11 @@ function Get-ComputerService {
             }
 
             $params = @{
-                ClassName = "Win32_Service"
-                ComputerName = $ComputerName
+                ClassName   = "Win32_Service"
                 ErrorAction = "Stop"
             }
-            if ($filter) { $params.Filter = $filter }
+            if ($filter)    { $params.Filter       = $filter       }
+            if (-not $isLocal) { $params.ComputerName = $ComputerName }
 
             $services = Get-CimInstance @params
             

--- a/LazyWinAdminModule/Private/Get-ComputerSoftware.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerSoftware.ps1
@@ -17,9 +17,12 @@ function Get-ComputerSoftware {
 
     process {
         try {
-            $hive = [UInt32]2147483650  # HKLM
+            $hive    = [UInt32]2147483650  # HKLM
+            $isLocal = $ComputerName -iin @('localhost', '127.0.0.1', $env:COMPUTERNAME)
 
-            $reg = Get-CimInstance -ComputerName $ComputerName -Namespace "root\default" -ClassName StdRegProv -ErrorAction Stop
+            $regParams = @{ Namespace = "root\default"; ClassName = "StdRegProv"; ErrorAction = "Stop" }
+            if (-not $isLocal) { $regParams.ComputerName = $ComputerName }
+            $reg = Get-CimInstance @regParams
 
             $uninstallPaths = @(
                 "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",

--- a/LazyWinAdminModule/Private/Get-ComputerSoftware.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerSoftware.ps1
@@ -1,11 +1,53 @@
 function Get-ComputerSoftware {
     <#
     .SYNOPSIS
-        Retrieves installed software from a remote computer via registry enumeration.
+        Retrieves installed software from a local or remote computer via registry enumeration.
+
     .DESCRIPTION
         Uses StdRegProv via CIM to read Uninstall keys from HKLM.
         This avoids Win32_Product which triggers an MSI consistency check on every query.
         Adheres to: software.* ALWAYS use-registry-enumeration (CONTRACTS)
+
+        Both the 64-bit and 32-bit (WOW6432Node) Uninstall hive paths are enumerated.
+        A case-insensitive HashSet deduplicates entries that appear in both hives so
+        each application is reported exactly once. Entries with no DisplayName are
+        silently skipped as they represent incomplete or in-progress installs.
+
+        InstallDate values are stored in YYYYMMDD format; the function attempts to
+        parse and reformat them as yyyy-MM-dd for readability. If parsing fails the
+        raw registry string is returned unchanged.
+
+    .PARAMETER ComputerName
+        The hostname or IP address of the target computer. This parameter is mandatory
+        because the function is typically called from a dispatcher that always supplies
+        the target explicitly.
+
+    .PARAMETER Search
+        Optional case-insensitive wildcard filter applied to the DisplayName field.
+        Supports standard PowerShell wildcard characters (* and ?).
+        Only entries whose DisplayName matches "*$Search*" are included in the output.
+        When omitted, all installed applications are returned.
+
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject[]
+        An array of software objects sorted alphabetically by Name, each with:
+            Name        [string] — DisplayName from the registry
+            Version     [string] — DisplayVersion from the registry (empty string if absent)
+            Vendor      [string] — Publisher from the registry (empty string if absent)
+            InstallDate [string] — Formatted as yyyy-MM-dd, raw YYYYMMDD string, or "Unknown"
+        Returns $null if the CIM/registry query fails.
+
+    .EXAMPLE
+        Get-ComputerSoftware -ComputerName "localhost"
+        Returns all installed software on the local machine.
+
+    .EXAMPLE
+        Get-ComputerSoftware -ComputerName "WORKSTATION42" -Search "Microsoft"
+        Returns all software entries whose DisplayName contains "Microsoft" on WORKSTATION42.
+
+    .EXAMPLE
+        Get-ComputerSoftware -ComputerName "SERVER01" | Where-Object Vendor -eq "Adobe Inc."
+        Returns all Adobe products installed on SERVER01.
     #>
     [CmdletBinding()]
     param (
@@ -17,7 +59,7 @@ function Get-ComputerSoftware {
 
     process {
         try {
-            $hive    = [UInt32]2147483650  # HKLM
+            $hive    = [UInt32]2147483650  # HKLM (HKEY_LOCAL_MACHINE = 0x80000002)
             $isLocal = $ComputerName -iin @('localhost', '127.0.0.1', $env:COMPUTERNAME)
 
             $regParams = @{ Namespace = "root\default"; ClassName = "StdRegProv"; ErrorAction = "Stop" }

--- a/LazyWinAdminModule/Private/Get-ComputerUptime.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerUptime.ps1
@@ -1,4 +1,41 @@
 function Get-ComputerUptime {
+    <#
+    .SYNOPSIS
+        Returns the uptime of a local or remote computer as a human-readable string.
+
+    .DESCRIPTION
+        Queries Win32_OperatingSystem via CIM to retrieve the LastBootUpTime
+        property, then computes the elapsed time relative to the current clock.
+        CIM natively deserialises LastBootUpTime as a [DateTime] object, so no
+        manual WMI DMTF-string conversion is required.
+
+        When ComputerName resolves to the local machine (localhost, 127.0.0.1,
+        or $env:COMPUTERNAME) no CIM ComputerName parameter is sent, avoiding
+        an unnecessary remote-protocol hop.
+
+    .PARAMETER ComputerName
+        The hostname or IP address of the target computer.
+        Defaults to "localhost" (the local machine).
+        Accepts pipeline input.
+
+    .OUTPUTS
+        System.String
+        A formatted uptime string: "<D> Days <H> Hours <M> Minutes <S> Seconds"
+        Returns "Unknown" if LastBootUpTime is not available.
+        Returns "Error" if the CIM query throws an exception.
+
+    .EXAMPLE
+        Get-ComputerUptime
+        Returns the uptime of the local machine, e.g. "3 Days 4 Hours 22 Minutes 10 Seconds".
+
+    .EXAMPLE
+        Get-ComputerUptime -ComputerName "SERVER01"
+        Returns the uptime string for SERVER01.
+
+    .EXAMPLE
+        "SERVER01","SERVER02" | Get-ComputerUptime
+        Returns the uptime string for each computer in the pipeline.
+    #>
     [CmdletBinding()]
     param (
         [Parameter(ValueFromPipeline=$true)]
@@ -11,17 +48,17 @@ function Get-ComputerUptime {
             $cimParams = @{ ClassName = "Win32_OperatingSystem"; ErrorAction = "Stop" }
             if (-not $isLocal) { $cimParams.ComputerName = $ComputerName }
             $cim = Get-CimInstance @cimParams
-            
+
             # CIM natively returns a DateTime object for LastBootUpTime, no need to convert like WMI
             if ($cim -and $cim.LastBootUpTime) {
                 $LBTime = $cim.LastBootUpTime
                 $uptime = New-TimeSpan -Start $LBTime -End (Get-Date)
-                
+
                 $days = $uptime.Days
                 $hours = $uptime.Hours
                 $minutes = $uptime.Minutes
                 $seconds = $uptime.Seconds
-                
+
                 return "$days Days $hours Hours $minutes Minutes $seconds Seconds"
             }
             return "Unknown"

--- a/LazyWinAdminModule/Private/Get-ComputerUptime.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerUptime.ps1
@@ -7,8 +7,10 @@ function Get-ComputerUptime {
 
     process {
         try {
-            # Replaced deprecated Get-WmiObject with Get-CimInstance (uses WSMan/WinRM)
-            $cim = Get-CimInstance -ClassName Win32_OperatingSystem -ComputerName $ComputerName -ErrorAction Stop
+            $isLocal   = $ComputerName -iin @('localhost', '127.0.0.1', $env:COMPUTERNAME)
+            $cimParams = @{ ClassName = "Win32_OperatingSystem"; ErrorAction = "Stop" }
+            if (-not $isLocal) { $cimParams.ComputerName = $ComputerName }
+            $cim = Get-CimInstance @cimParams
             
             # CIM natively returns a DateTime object for LastBootUpTime, no need to convert like WMI
             if ($cim -and $cim.LastBootUpTime) {

--- a/LazyWinAdminModule/Private/Get-DeviceComplianceStatus.ps1
+++ b/LazyWinAdminModule/Private/Get-DeviceComplianceStatus.ps1
@@ -1,0 +1,106 @@
+function Get-DeviceComplianceStatus {
+    <#
+    .SYNOPSIS
+        Checks local device compliance items and returns a status list.
+    .DESCRIPTION
+        Checks: Location Services policy/consent, OneDrive installation,
+        Outlook external image download setting, Windows Update active hours,
+        and Unified Write Filter state (Enterprise only).
+        All checks are registry/WMI reads — no network required.
+    #>
+    [CmdletBinding()]
+    param ()
+
+    $results = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+    # 1. Location Services
+    try {
+        $policyPath  = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\LocationAndSensors'
+        $svcCfgPath  = 'HKLM:\SYSTEM\CurrentControlSet\Services\lfsvc\Service\Configuration'
+        $consentPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\location'
+
+        $policyLocked = $false
+        foreach ($flag in @('DisableLocation', 'DisableWindowsLocationProvider', 'DisableSensors')) {
+            $v = (Get-ItemProperty -Path $policyPath -ErrorAction SilentlyContinue).$flag
+            if (($v -as [int]) -eq 1) { $policyLocked = $true }
+        }
+        $svcCfg  = (Get-ItemProperty -Path $svcCfgPath  -ErrorAction SilentlyContinue).Status
+        $consent = (Get-ItemProperty -Path $consentPath  -ErrorAction SilentlyContinue).Value
+
+        $status = if (-not $policyLocked -and ($svcCfg -as [int]) -eq 1 -and $consent -match '^(?i)Allow$') {
+            'Compliant'
+        } else {
+            'Non-Compliant'
+        }
+        $detail = "Policy blocked: $policyLocked | Service cfg: $svcCfg | Consent: $consent"
+    }
+    catch {
+        $status = 'Error'; $detail = "Could not read location registry keys."
+    }
+    $results.Add([PSCustomObject]@{ Item = 'Location Services'; Status = $status; Description = $detail })
+
+    # 2. OneDrive
+    try {
+        $installed = (Test-Path "$env:SystemRoot\System32\OneDriveSetup.exe") -or
+                     (Test-Path "$env:SystemRoot\SysWOW64\OneDriveSetup.exe")
+        $status = if ($installed) { 'Installed' } else { 'Not Installed' }
+        $detail = if ($installed) { 'OneDrive setup executable found on disk' } else { 'OneDrive setup executable not found' }
+    }
+    catch {
+        $status = 'Error'; $detail = "Could not check OneDrive installation."
+    }
+    $results.Add([PSCustomObject]@{ Item = 'OneDrive'; Status = $status; Description = $detail })
+
+    # 3. Outlook external image auto-download
+    try {
+        $regPath = 'HKCU:\Software\Microsoft\Office\16.0\Outlook\Options\Mail'
+        $v       = (Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue).BlockExtContent
+        $status  = if ($null -eq $v) { 'Not Configured' } elseif ($v -eq 0) { 'Compliant' } else { 'Blocked' }
+        $detail  = "BlockExtContent = $(if ($null -eq $v) { '(not set)' } else { $v })"
+    }
+    catch {
+        $status = 'Error'; $detail = "Could not read Outlook registry key."
+    }
+    $results.Add([PSCustomObject]@{ Item = 'Outlook External Images'; Status = $status; Description = $detail })
+
+    # 4. Windows Update active hours
+    try {
+        $regPath = 'HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings'
+        $reg     = Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue
+        $start   = $reg.ActiveHoursStart
+        $end     = $reg.ActiveHoursEnd
+        $status  = if ($null -ne $start -and $null -ne $end) { 'Configured' } else { 'Not Configured' }
+        $detail  = if ($null -ne $start) { "Active hours: $($start):00 to $($end):00" } else { 'Active hours not set' }
+    }
+    catch {
+        $status = 'Error'; $detail = "Could not read Windows Update registry key."
+    }
+    $results.Add([PSCustomObject]@{ Item = 'Windows Update Active Hours'; Status = $status; Description = $detail })
+
+    # 5. Unified Write Filter (Enterprise only)
+    try {
+        $osCaption = (Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction SilentlyContinue).Caption
+        if ($osCaption -like '*Enterprise*') {
+            $feature = Get-WindowsOptionalFeature -Online -FeatureName 'Client-UnifiedWriteFilter' -ErrorAction SilentlyContinue
+            if ($feature.State -eq 'Enabled') {
+                $uwf    = Get-WmiObject -Namespace 'root\standardcimv2\embedded' -Class 'UWF_Filter' -ErrorAction SilentlyContinue
+                $status = if ($uwf.CurrentEnabled) { 'Enabled' } else { 'Disabled' }
+                $detail = 'UWF feature installed; CurrentEnabled = ' + $uwf.CurrentEnabled
+            }
+            else {
+                $status = 'Feature Not Installed'
+                $detail = 'Windows Enterprise detected but UWF optional feature is not enabled'
+            }
+        }
+        else {
+            $status = 'N/A'
+            $detail = 'Unified Write Filter requires Windows Enterprise'
+        }
+    }
+    catch {
+        $status = 'Error'; $detail = "Could not check UWF state."
+    }
+    $results.Add([PSCustomObject]@{ Item = 'Unified Write Filter'; Status = $status; Description = $detail })
+
+    return $results
+}

--- a/LazyWinAdminModule/Private/Get-DeviceComplianceStatus.ps1
+++ b/LazyWinAdminModule/Private/Get-DeviceComplianceStatus.ps1
@@ -7,6 +7,13 @@ function Get-DeviceComplianceStatus {
         Outlook external image download setting, Windows Update active hours,
         and Unified Write Filter state (Enterprise only).
         All checks are registry/WMI reads — no network required.
+    .OUTPUTS
+        System.Collections.Generic.List[PSCustomObject] — each object has three properties:
+          Item        (System.String) — the compliance check name.
+          Status      (System.String) — check outcome, e.g. Compliant, Non-Compliant,
+                                        Installed, Not Installed, Configured, Not Configured,
+                                        Enabled, Disabled, Feature Not Installed, N/A, Error.
+          Description (System.String) — human-readable detail about the check result.
     #>
     [CmdletBinding()]
     param ()
@@ -20,12 +27,15 @@ function Get-DeviceComplianceStatus {
         $consentPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\location'
 
         $policyLocked = $false
+        $policyReg    = Get-ItemProperty -Path $policyPath -ErrorAction SilentlyContinue
         foreach ($flag in @('DisableLocation', 'DisableWindowsLocationProvider', 'DisableSensors')) {
-            $v = (Get-ItemProperty -Path $policyPath -ErrorAction SilentlyContinue).$flag
+            $v = if ($null -ne $policyReg) { $policyReg.$flag } else { $null }
             if (($v -as [int]) -eq 1) { $policyLocked = $true }
         }
-        $svcCfg  = (Get-ItemProperty -Path $svcCfgPath  -ErrorAction SilentlyContinue).Status
-        $consent = (Get-ItemProperty -Path $consentPath  -ErrorAction SilentlyContinue).Value
+        $svcReg  = Get-ItemProperty -Path $svcCfgPath  -ErrorAction SilentlyContinue
+        $conReg  = Get-ItemProperty -Path $consentPath  -ErrorAction SilentlyContinue
+        $svcCfg  = if ($null -ne $svcReg) { $svcReg.Status } else { $null }
+        $consent = if ($null -ne $conReg) { $conReg.Value  } else { $null }
 
         $status = if (-not $policyLocked -and ($svcCfg -as [int]) -eq 1 -and $consent -match '^(?i)Allow$') {
             'Compliant'
@@ -54,7 +64,8 @@ function Get-DeviceComplianceStatus {
     # 3. Outlook external image auto-download
     try {
         $regPath = 'HKCU:\Software\Microsoft\Office\16.0\Outlook\Options\Mail'
-        $v       = (Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue).BlockExtContent
+        $outlookReg = Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue
+        $v          = if ($null -ne $outlookReg) { $outlookReg.BlockExtContent } else { $null }
         $status  = if ($null -eq $v) { 'Not Configured' } elseif ($v -eq 0) { 'Compliant' } else { 'Blocked' }
         $detail  = "BlockExtContent = $(if ($null -eq $v) { '(not set)' } else { $v })"
     }
@@ -67,8 +78,8 @@ function Get-DeviceComplianceStatus {
     try {
         $regPath = 'HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings'
         $reg     = Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue
-        $start   = $reg.ActiveHoursStart
-        $end     = $reg.ActiveHoursEnd
+        $start   = if ($null -ne $reg) { $reg.ActiveHoursStart } else { $null }
+        $end     = if ($null -ne $reg) { $reg.ActiveHoursEnd   } else { $null }
         $status  = if ($null -ne $start -and $null -ne $end) { 'Configured' } else { 'Not Configured' }
         $detail  = if ($null -ne $start) { "Active hours: $($start):00 to $($end):00" } else { 'Active hours not set' }
     }
@@ -83,7 +94,7 @@ function Get-DeviceComplianceStatus {
         if ($osCaption -like '*Enterprise*') {
             $feature = Get-WindowsOptionalFeature -Online -FeatureName 'Client-UnifiedWriteFilter' -ErrorAction SilentlyContinue
             if ($feature.State -eq 'Enabled') {
-                $uwf    = Get-WmiObject -Namespace 'root\standardcimv2\embedded' -Class 'UWF_Filter' -ErrorAction SilentlyContinue
+                $uwf    = Get-CimInstance -Namespace 'root\standardcimv2\embedded' -ClassName 'UWF_Filter' -ErrorAction SilentlyContinue
                 $status = if ($uwf.CurrentEnabled) { 'Enabled' } else { 'Disabled' }
                 $detail = 'UWF feature installed; CurrentEnabled = ' + $uwf.CurrentEnabled
             }

--- a/LazyWinAdminModule/Private/Get-EntraIdentity.ps1
+++ b/LazyWinAdminModule/Private/Get-EntraIdentity.ps1
@@ -2,6 +2,32 @@ function Get-EntraIdentity {
     <#
     .SYNOPSIS
         Retrieves users or groups from Entra ID using Microsoft Graph.
+    .DESCRIPTION
+        Queries Microsoft Graph using OData $filter expressions against the
+        displayName and (for users) userPrincipalName properties.
+        Results are limited to a maximum of 50 objects per call (-Top 50).
+
+        Input validation rejects characters not safe for OData $filter strings
+        before the query is constructed. Single quotes in the search term are
+        escaped as two consecutive single quotes so that the OData filter string
+        remains syntactically valid and cannot be broken by user input.
+
+        Requires an active Microsoft Graph session (Connect-ModernCloud or
+        Connect-MgGraph) with at least User.ReadBasic.All and Group.Read.All scopes.
+    .PARAMETER Type
+        Object type to query. Valid values: User, Group.
+    .PARAMETER Search
+        Optional search string. Must contain only alphanumeric characters, spaces,
+        hyphens, dots, @ signs, and underscores. Single quotes are automatically
+        escaped. When provided, a startsWith OData filter is applied; when omitted,
+        the first 50 objects of the requested type are returned (-Top 50 pagination
+        limit applies in both cases).
+    .OUTPUTS
+        System.Object[] — array of selected properties, or $null on error or when
+        not connected to Graph.
+
+        User objects include: DisplayName, UserPrincipalName, Id, Mail, JobTitle.
+        Group objects include: DisplayName, Id, Description, GroupTypes.
     #>
     [CmdletBinding()]
     param (
@@ -27,7 +53,7 @@ function Get-EntraIdentity {
 
             if ($Type -eq "User") {
                 if ($Search) {
-                    $SafeSearch = $Search.Trim()
+                    $SafeSearch = $Search.Trim() -replace "'", "''"
                     return Get-MgUser `
                         -Filter "startsWith(displayName,'$SafeSearch') or startsWith(userPrincipalName,'$SafeSearch')" `
                         -Top 50 |
@@ -38,7 +64,7 @@ function Get-EntraIdentity {
             }
             else {
                 if ($Search) {
-                    $SafeSearch = $Search.Trim()
+                    $SafeSearch = $Search.Trim() -replace "'", "''"
                     return Get-MgGroup `
                         -Filter "startsWith(displayName,'$SafeSearch')" `
                         -Top 50 |

--- a/LazyWinAdminModule/Private/Get-ExchangeMailboxPermission.ps1
+++ b/LazyWinAdminModule/Private/Get-ExchangeMailboxPermission.ps1
@@ -1,0 +1,42 @@
+function Get-ExchangeMailboxPermission {
+    <#
+    .SYNOPSIS
+        Lists all shared mailboxes a given user has FullAccess or SendAs on.
+    .DESCRIPTION
+        Iterates every shared mailbox in the connected Exchange Online organisation
+        and checks whether the target user holds FullAccess (via Get-MailboxPermission)
+        or SendAs (via Get-RecipientPermission). Returns only mailboxes where at
+        least one permission is held.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]$UserPrincipalName
+    )
+
+    try {
+        $sharedMailboxes = Get-Mailbox -RecipientTypeDetails SharedMailbox -ErrorAction Stop
+
+        $results = foreach ($mailbox in $sharedMailboxes) {
+            $fa = Get-MailboxPermission -Identity $mailbox.Alias -ErrorAction SilentlyContinue |
+                      Where-Object { $_.User -like $UserPrincipalName -and $_.AccessRights -contains 'FullAccess' }
+            $sa = Get-RecipientPermission -Identity $mailbox.Alias -ErrorAction SilentlyContinue |
+                      Where-Object { $_.Trustee -like $UserPrincipalName -and $_.AccessRights -contains 'SendAs' }
+
+            if ($fa -or $sa) {
+                [PSCustomObject]@{
+                    Mailbox     = $mailbox.PrimarySmtpAddress
+                    DisplayName = $mailbox.DisplayName
+                    FullAccess  = [bool]$fa
+                    SendAs      = [bool]$sa
+                }
+            }
+        }
+
+        return $results
+    }
+    catch {
+        Write-Warning "Error querying mailbox permissions: $_"
+        return $null
+    }
+}

--- a/LazyWinAdminModule/Private/Get-ExchangeMailboxPermission.ps1
+++ b/LazyWinAdminModule/Private/Get-ExchangeMailboxPermission.ps1
@@ -7,6 +7,17 @@ function Get-ExchangeMailboxPermission {
         and checks whether the target user holds FullAccess (via Get-MailboxPermission)
         or SendAs (via Get-RecipientPermission). Returns only mailboxes where at
         least one permission is held.
+    .PARAMETER UserPrincipalName
+        UPN of the user to check, e.g. 'user@contoso.com'. Must be in standard
+        UPN format (local-part@domain.tld). Invalid format returns $null with a
+        Write-Warning message.
+    .OUTPUTS
+        System.Object[] — array of PSCustomObject with properties:
+          Mailbox     (System.String)  — primary SMTP address of the shared mailbox.
+          DisplayName (System.String)  — display name of the shared mailbox.
+          FullAccess  (System.Boolean) — $true if the user holds FullAccess.
+          SendAs      (System.Boolean) — $true if the user holds SendAs.
+        Returns $null on UPN validation failure or on error.
     #>
     [CmdletBinding()]
     param (
@@ -15,6 +26,11 @@ function Get-ExchangeMailboxPermission {
     )
 
     try {
+        if ($UserPrincipalName -notmatch '^[^@\s]+@[^@\s]+\.[^@\s]+$') {
+            Write-Warning "UserPrincipalName '$UserPrincipalName' is not a valid UPN format."
+            return $null
+        }
+
         $sharedMailboxes = Get-Mailbox -RecipientTypeDetails SharedMailbox -ErrorAction Stop
 
         $results = foreach ($mailbox in $sharedMailboxes) {

--- a/LazyWinAdminModule/Private/Get-IntuneDevice.ps1
+++ b/LazyWinAdminModule/Private/Get-IntuneDevice.ps1
@@ -2,6 +2,28 @@ function Get-IntuneDevice {
     <#
     .SYNOPSIS
         Retrieves managed devices from Microsoft Intune using Microsoft Graph.
+    .DESCRIPTION
+        Queries the Intune managed device endpoint via Microsoft Graph using OData
+        $filter expressions against deviceName and userPrincipalName.
+        Results are limited to a maximum of 50 devices per call (-Top 50).
+
+        Input validation rejects characters not safe for OData $filter strings before
+        the query is constructed. Single quotes in the search term are escaped as two
+        consecutive single quotes to prevent OData filter string breakage.
+
+        Requires an active Microsoft Graph session with at least
+        DeviceManagementManagedDevices.Read.All scope.
+    .PARAMETER Search
+        Optional filter string. Must contain only alphanumeric characters, spaces,
+        hyphens, dots, @ signs, and underscores. Single quotes are automatically
+        escaped. When provided, a startsWith OData filter is applied against both
+        deviceName and userPrincipalName; when omitted, the first 50 devices are
+        returned (-Top 50 pagination limit applies in both cases).
+    .OUTPUTS
+        System.Object[] — array of PSCustomObject with properties:
+        DeviceName, UserPrincipalName, ComplianceState, OperatingSystem, Model,
+        SerialNumber, JoinType, ManagementState, DeviceEnrollmentType.
+        Returns $null on error or when not connected to Graph.
     #>
     [CmdletBinding()]
     param (
@@ -22,7 +44,7 @@ function Get-IntuneDevice {
             }
 
             if ($Search) {
-                $SafeSearch = $Search.Trim()
+                $SafeSearch = $Search.Trim() -replace "'", "''"
                 return Get-MgDeviceManagementManagedDevice `
                     -Filter "startsWith(deviceName,'$SafeSearch') or startsWith(userPrincipalName,'$SafeSearch')" `
                     -Top 50 |

--- a/LazyWinAdminModule/Private/Get-IntuneManagementScript.ps1
+++ b/LazyWinAdminModule/Private/Get-IntuneManagementScript.ps1
@@ -12,6 +12,22 @@ function Get-IntuneManagementScript {
     .PARAMETER DownloadPath
         If specified and the path exists, each script's content is base64-decoded
         and written as a .ps1 file under this folder.
+    .OUTPUTS
+        System.Object[] — array of PSCustomObject with properties:
+          Id          (System.String)   — Intune script GUID.
+          DisplayName (System.String)   — friendly name of the script.
+          FileName    (System.String)   — original filename (e.g. 'Deploy-App.ps1').
+          RunAs       (System.String)   — execution context, e.g. 'system' or 'user'.
+          Enforcement (System.String)   — enforcement type reported by Intune.
+          Created     (System.DateTime) — script creation timestamp.
+          Modified    (System.DateTime) — last modification timestamp.
+        Returns $null when not connected to Graph or when an error occurs.
+    .EXAMPLE
+        # List all Intune management scripts
+        Get-IntuneManagementScript
+    .EXAMPLE
+        # Filter scripts by name and download them locally
+        Get-IntuneManagementScript -Search 'Deploy' -DownloadPath 'C:\Temp\IntuneScripts'
     #>
     [CmdletBinding()]
     param (

--- a/LazyWinAdminModule/Private/Get-IntuneManagementScript.ps1
+++ b/LazyWinAdminModule/Private/Get-IntuneManagementScript.ps1
@@ -1,0 +1,81 @@
+function Get-IntuneManagementScript {
+    <#
+    .SYNOPSIS
+        Lists Intune device management scripts and optionally downloads their content.
+    .DESCRIPTION
+        Uses Invoke-MgGraphRequest (Microsoft.Graph.Authentication) against the
+        beta Graph endpoint for deviceManagementScripts.  Requires an active
+        Graph session with DeviceManagementConfiguration.Read.All scope.
+    .PARAMETER Search
+        Optional name/filename filter — returns scripts whose DisplayName or
+        FileName contains the search string (case-insensitive).
+    .PARAMETER DownloadPath
+        If specified and the path exists, each script's content is base64-decoded
+        and written as a .ps1 file under this folder.
+    #>
+    [CmdletBinding()]
+    param (
+        [string]$Search,
+        [string]$DownloadPath
+    )
+
+    try {
+        $ctx = Get-MgContext -ErrorAction SilentlyContinue
+        if (-not $ctx) {
+            Write-Warning "Not connected to Microsoft Graph. Please authenticate on the Cloud Auth tab."
+            return $null
+        }
+
+        $response = Invoke-MgGraphRequest -Method GET `
+            -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts" `
+            -ErrorAction Stop
+
+        $scripts = $response.value
+
+        if ($Search) {
+            $scripts = $scripts | Where-Object {
+                $_.fileName    -like "*$Search*" -or
+                $_.displayName -like "*$Search*"
+            }
+        }
+
+        if ($DownloadPath) {
+            if (-not (Test-Path $DownloadPath)) {
+                New-Item -ItemType Directory -Path $DownloadPath -Force | Out-Null
+            }
+
+            foreach ($script in $scripts) {
+                try {
+                    $detail = Invoke-MgGraphRequest -Method GET `
+                        -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts/$($script.id)" `
+                        -ErrorAction Stop
+                    if ($detail.scriptContent) {
+                        $decoded  = [System.Text.Encoding]::UTF8.GetString(
+                                        [System.Convert]::FromBase64String($detail.scriptContent))
+                        $filePath = Join-Path $DownloadPath $detail.fileName
+                        $decoded | Out-File -FilePath $filePath -Encoding UTF8 -Force
+                    }
+                }
+                catch {
+                    Write-Warning "Could not download script '$($script.displayName)': $_"
+                }
+            }
+        }
+
+        return $scripts | ForEach-Object {
+            [PSCustomObject]@{
+                Id          = $_.id
+                DisplayName = $_.displayName
+                FileName    = $_.fileName
+                RunAs       = $_.runAsAccount
+                Enforcement = $_.enforcementType
+                Created     = $_.createdDateTime
+                Modified    = $_.lastModifiedDateTime
+            }
+        }
+    }
+    catch {
+        Write-Warning "Error querying Intune management scripts: $_"
+        return $null
+    }
+}

--- a/LazyWinAdminModule/Private/Invoke-ComputerRegistry.ps1
+++ b/LazyWinAdminModule/Private/Invoke-ComputerRegistry.ps1
@@ -40,7 +40,10 @@ function Invoke-ComputerRegistry {
             }
             $hDef = $hives[$Hive]
 
-            $reg = Get-CimInstance -ComputerName $ComputerName -Namespace "root\default" -ClassName StdRegProv -ErrorAction Stop
+            $isLocal   = $ComputerName -iin @('localhost', '127.0.0.1', $env:COMPUTERNAME)
+            $regParams = @{ Namespace = "root\default"; ClassName = "StdRegProv"; ErrorAction = "Stop" }
+            if (-not $isLocal) { $regParams.ComputerName = $ComputerName }
+            $reg = Get-CimInstance @regParams
 
             switch ($Action) {
                 "Get" {

--- a/LazyWinAdminModule/Private/Invoke-ComputerRegistry.ps1
+++ b/LazyWinAdminModule/Private/Invoke-ComputerRegistry.ps1
@@ -5,6 +5,37 @@ function Invoke-ComputerRegistry {
     .DESCRIPTION
         Uses CIM (StdRegProv) for cross-platform compatibility and performance.
         Adheres to: registry_entry.* REQUIRES hive-valid (CONTRACTS)
+    .PARAMETER Action
+        Registry operation to perform. Valid values: Get, Set, New, Remove.
+        Get — reads the named value (tries String then DWORD).
+        Set — writes the named value using the type specified by -ValueType.
+        New — creates the registry key at -KeyPath (no value written).
+        Remove — deletes either the named value (when -ValueName is provided)
+                 or the entire key (when -ValueName is omitted).
+    .PARAMETER ComputerName
+        Hostname or IP of the target computer. Localhost variants skip the remote
+        CIM session to avoid unnecessary WinRM overhead.
+    .PARAMETER Hive
+        Registry hive abbreviation. Valid values: HKCR, HKCU, HKLM, HKU.
+    .PARAMETER KeyPath
+        Registry key path relative to the hive root, e.g.
+        'SOFTWARE\Microsoft\Windows NT\CurrentVersion'.
+    .PARAMETER ValueName
+        Name of the registry value. Omit (or leave empty) when using Action=New,
+        or when Action=Remove targets the key itself rather than a value.
+    .PARAMETER Value
+        Data to write when Action=Set. Must be compatible with the chosen -ValueType.
+    .PARAMETER ValueType
+        Data type for Set operations. Valid values: String, ExpandString, Binary,
+        DWord, MultiString, QWord. Defaults to String.
+        Note: Binary, ExpandString, and MultiString types are not yet fully
+        implemented and will return $false with a warning.
+    .OUTPUTS
+        Action=Get  — System.String or System.UInt32 (value data), or $null if not found.
+        Action=Set  — System.Boolean ($true on success, $false on failure).
+        Action=New  — System.Boolean ($true on success, $false on failure).
+        Action=Remove — System.Boolean ($true on success, $false on failure).
+        On unhandled exception — $null.
     #>
     [CmdletBinding()]
     param (

--- a/LazyWinAdminModule/Private/Set-ComputerRDP.ps1
+++ b/LazyWinAdminModule/Private/Set-ComputerRDP.ps1
@@ -30,7 +30,8 @@ function Set-ComputerRDP {
     process {
         $CimSession = $null
         try {
-            $CimSession = New-CimSession -ComputerName $ComputerName -ErrorAction Stop
+            $isLocal    = $ComputerName -iin @('localhost', '127.0.0.1', $env:COMPUTERNAME)
+            $CimSession = if ($isLocal) { New-CimSession -ErrorAction Stop } else { New-CimSession -ComputerName $ComputerName -ErrorAction Stop }
 
             # --- STEP 3: computer.set_rdp_registry ---
             # Toggle fDenyTSConnections in the Terminal Server registry key.

--- a/LazyWinAdminModule/Private/Set-ComputerRDP.ps1
+++ b/LazyWinAdminModule/Private/Set-ComputerRDP.ps1
@@ -1,7 +1,8 @@
 function Set-ComputerRDP {
     <#
     .SYNOPSIS
-        Enables or Disables Remote Desktop on a remote computer.
+        Enables or Disables Remote Desktop on a local or remote computer.
+
     .DESCRIPTION
         Implements rdp_toggle FLOW steps 3 and 4 as two distinct CIM operations
         over a single shared CimSession:
@@ -17,6 +18,41 @@ function Set-ComputerRDP {
         Previously both operations were combined in a single SetAllowTSConnections CIM method
         call. Splitting them makes each step independently verifiable and rollback-safe.
         Adheres to: cim_session.* ALWAYS reuse-before-create (CONTRACTS)
+
+        Exception detail (stack traces, error codes) is intentionally not surfaced in the
+        return value to prevent leaking internal state to the UI layer. A generic error
+        string is returned instead, and the full exception is emitted via Write-Warning
+        for capture by the module's logging infrastructure.
+
+    .PARAMETER ComputerName
+        The hostname or IP address of the target computer. Mandatory.
+        The value is also embedded in the success/failure return string so the caller
+        can correlate the result when processing multiple machines.
+
+    .PARAMETER Enabled
+        Boolean flag controlling the desired RDP state.
+            $true  — Enable RDP (sets fDenyTSConnections = 0, enables firewall rules)
+            $false — Disable RDP (sets fDenyTSConnections = 1, disables firewall rules)
+
+    .OUTPUTS
+        System.String
+        "RDP Enabled on <ComputerName>"  — both registry and firewall steps succeeded.
+        "RDP Disabled on <ComputerName>" — both registry and firewall steps succeeded.
+        "Error: RDP operation failed on <ComputerName>" — one or both steps failed;
+            consult the warning stream for the underlying exception message.
+
+    .EXAMPLE
+        Set-ComputerRDP -ComputerName "WORKSTATION42" -Enabled $true
+        Enables Remote Desktop on WORKSTATION42 and returns "RDP Enabled on WORKSTATION42".
+
+    .EXAMPLE
+        Set-ComputerRDP -ComputerName "SERVER01" -Enabled $false
+        Disables Remote Desktop on SERVER01 and returns "RDP Disabled on SERVER01".
+
+    .EXAMPLE
+        $result = Set-ComputerRDP -ComputerName "localhost" -Enabled $true
+        if ($result -like "Error*") { Write-Error $result }
+        Enables RDP on the local machine and checks for failure.
     #>
     [CmdletBinding()]
     param (
@@ -40,7 +76,7 @@ function Set-ComputerRDP {
                                -ClassName StdRegProv -ErrorAction Stop
             $fDenyValue  = if ($Enabled) { [uint32]0 } else { [uint32]1 }
             $regResult   = Invoke-CimMethod -InputObject $reg -MethodName "SetDWORDValue" -Arguments @{
-                hDefKey     = [uint32]2147483650  # HKLM
+                hDefKey     = [uint32]2147483650  # HKLM (HKEY_LOCAL_MACHINE = 0x80000002)
                 sSubKeyName = "SYSTEM\CurrentControlSet\Control\Terminal Server"
                 sValueName  = "fDenyTSConnections"
                 uValue      = $fDenyValue

--- a/LazyWinAdminModule/Private/Set-DeviceComplianceItem.ps1
+++ b/LazyWinAdminModule/Private/Set-DeviceComplianceItem.ps1
@@ -1,0 +1,119 @@
+function Set-DeviceComplianceItem {
+    <#
+    .SYNOPSIS
+        Remediates a local device compliance item.
+    .DESCRIPTION
+        Supported items:
+          LocationServices       — clears policy blocks, sets consent to Allow,
+                                   restarts lfsvc (requires Administrator).
+          OutlookExternalImages  — sets BlockExtContent = 0 in HKCU (no admin needed).
+          WindowsUpdateActiveHours — sets ActiveHoursStart/End in HKLM (requires Administrator).
+          RemoveOneDrive         — uninstalls OneDrive, cleans registry and files
+                                   (requires Administrator).
+    .PARAMETER Item
+        The compliance item to remediate.
+    .PARAMETER ActiveHoursStart
+        Start of Windows Update active hours, 0–23 (default 8). Used only with
+        WindowsUpdateActiveHours.
+    .PARAMETER ActiveHoursEnd
+        End of Windows Update active hours, 0–23 (default 18). Used only with
+        WindowsUpdateActiveHours.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('LocationServices', 'OutlookExternalImages', 'WindowsUpdateActiveHours', 'RemoveOneDrive')]
+        [string]$Item,
+
+        [ValidateRange(0, 23)]
+        [int]$ActiveHoursStart = 8,
+
+        [ValidateRange(0, 23)]
+        [int]$ActiveHoursEnd = 18
+    )
+
+    try {
+        switch ($Item) {
+
+            'LocationServices' {
+                $policyPath  = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\LocationAndSensors'
+                $svcCfgPath  = 'HKLM:\SYSTEM\CurrentControlSet\Services\lfsvc\Service\Configuration'
+                $consentPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\location'
+
+                if (-not (Test-Path $policyPath)) { New-Item -Path $policyPath -Force | Out-Null }
+                foreach ($flag in @('DisableLocation', 'DisableWindowsLocationProvider', 'DisableSensors')) {
+                    Set-ItemProperty -Path $policyPath -Name $flag -Value 0 -Type DWord -Force
+                }
+
+                if (-not (Test-Path $svcCfgPath)) { New-Item -Path $svcCfgPath -Force | Out-Null }
+                Set-ItemProperty -Path $svcCfgPath -Name 'Status' -Value 1 -Type DWord -Force
+
+                if (-not (Test-Path $consentPath)) { New-Item -Path $consentPath -Force | Out-Null }
+                Set-ItemProperty -Path $consentPath -Name 'Value' -Value 'Allow' -Type String -Force
+
+                # Set Allow for all currently loaded user hives
+                Get-ChildItem Registry::HKEY_USERS |
+                    Where-Object { $_.Name -match 'S-1-5-21-\d+-\d+-\d+-\d+$' } |
+                    ForEach-Object {
+                        $userConsent = "Registry::HKEY_USERS\$($_.PSChildName)\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\location"
+                        if (-not (Test-Path $userConsent)) { New-Item -Path $userConsent -Force | Out-Null }
+                        Set-ItemProperty -Path $userConsent -Name 'Value' -Value 'Allow' -Type String -Force
+                    }
+
+                try { Restart-Service -Name 'lfsvc' -Force -ErrorAction SilentlyContinue } catch {}
+
+                return "[OK] Location Services enabled and consent set to Allow"
+            }
+
+            'OutlookExternalImages' {
+                $regPath = 'HKCU:\Software\Microsoft\Office\16.0\Outlook\Options\Mail'
+                if (-not (Test-Path $regPath)) { New-Item -Path $regPath -Force | Out-Null }
+                Set-ItemProperty -Path $regPath -Name 'BlockExtContent' -Value 0 -Type DWord -Force
+                return "[OK] Outlook external image download enabled (BlockExtContent = 0)"
+            }
+
+            'WindowsUpdateActiveHours' {
+                if ($ActiveHoursStart -eq $ActiveHoursEnd) {
+                    return "[!] Active hours start and end cannot be the same value."
+                }
+                $regPath = 'HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings'
+                if (-not (Test-Path $regPath)) { New-Item -Path $regPath -Force | Out-Null }
+                Set-ItemProperty -Path $regPath -Name 'ActiveHoursStart' -Value $ActiveHoursStart -Type DWord -Force
+                Set-ItemProperty -Path $regPath -Name 'ActiveHoursEnd'   -Value $ActiveHoursEnd   -Type DWord -Force
+                return "[OK] Windows Update active hours set to $($ActiveHoursStart):00 - $($ActiveHoursEnd):00"
+            }
+
+            'RemoveOneDrive' {
+                Get-Process -Name OneDrive -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+                foreach ($setup in @(
+                    "$env:SystemRoot\System32\OneDriveSetup.exe",
+                    "$env:SystemRoot\SysWOW64\OneDriveSetup.exe"
+                )) {
+                    if (Test-Path $setup) {
+                        Start-Process -FilePath $setup -ArgumentList '/uninstall' -NoNewWindow -Wait -ErrorAction SilentlyContinue
+                    }
+                }
+
+                # File cleanup
+                Remove-Item -Path "$env:LocalAppData\Microsoft\OneDrive" -Recurse -Force -ErrorAction SilentlyContinue
+                Remove-Item -Path "$env:AppData\Microsoft\OneDrive"      -Recurse -Force -ErrorAction SilentlyContinue
+                Remove-Item -Path "$env:ProgramData\Microsoft OneDrive"  -Recurse -Force -ErrorAction SilentlyContinue
+                Remove-Item -Path "C:\OneDriveTemp"                      -Recurse -Force -ErrorAction SilentlyContinue
+
+                # Registry cleanup
+                Remove-Item -Path 'HKCU:\Software\Microsoft\OneDrive'              -Recurse -Force -ErrorAction SilentlyContinue
+                Remove-Item -Path 'HKLM:\SOFTWARE\Microsoft\OneDrive'              -Recurse -Force -ErrorAction SilentlyContinue
+                Remove-Item -Path 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\OneDrive'  -Recurse -Force -ErrorAction SilentlyContinue
+                Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' `
+                    -Name 'OneDrive' -ErrorAction SilentlyContinue
+
+                return "[OK] OneDrive removed and cleanup complete"
+            }
+        }
+    }
+    catch {
+        Write-Warning "Compliance remediation failed for '$Item': $_"
+        return "[!] Remediation failed for '$Item'. Some steps may require Administrator rights."
+    }
+}

--- a/LazyWinAdminModule/Private/Set-DeviceComplianceItem.ps1
+++ b/LazyWinAdminModule/Private/Set-DeviceComplianceItem.ps1
@@ -10,6 +10,9 @@ function Set-DeviceComplianceItem {
           WindowsUpdateActiveHours — sets ActiveHoursStart/End in HKLM (requires Administrator).
           RemoveOneDrive         — uninstalls OneDrive, cleans registry and files
                                    (requires Administrator).
+    .OUTPUTS
+        System.String — starts with '[OK]' on success or '[!]' on validation error or
+        partial failure. On unhandled exception returns '[!] Remediation failed…'.
     .PARAMETER Item
         The compliance item to remediate.
     .PARAMETER ActiveHoursStart
@@ -84,31 +87,46 @@ function Set-DeviceComplianceItem {
             }
 
             'RemoveOneDrive' {
+                # Stop process first (best-effort)
                 Get-Process -Name OneDrive -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
+                # Run uninstallers and track success
+                $uninstallRan = $false
                 foreach ($setup in @(
                     "$env:SystemRoot\System32\OneDriveSetup.exe",
                     "$env:SystemRoot\SysWOW64\OneDriveSetup.exe"
                 )) {
                     if (Test-Path $setup) {
-                        Start-Process -FilePath $setup -ArgumentList '/uninstall' -NoNewWindow -Wait -ErrorAction SilentlyContinue
+                        $proc = Start-Process -FilePath $setup -ArgumentList '/uninstall' -NoNewWindow -Wait -PassThru -ErrorAction SilentlyContinue
+                        if ($proc -and $proc.ExitCode -eq 0) { $uninstallRan = $true }
                     }
                 }
 
-                # File cleanup
-                Remove-Item -Path "$env:LocalAppData\Microsoft\OneDrive" -Recurse -Force -ErrorAction SilentlyContinue
-                Remove-Item -Path "$env:AppData\Microsoft\OneDrive"      -Recurse -Force -ErrorAction SilentlyContinue
-                Remove-Item -Path "$env:ProgramData\Microsoft OneDrive"  -Recurse -Force -ErrorAction SilentlyContinue
-                Remove-Item -Path "C:\OneDriveTemp"                      -Recurse -Force -ErrorAction SilentlyContinue
+                # File cleanup (best-effort)
+                $cleanupPaths = @(
+                    "$env:LocalAppData\Microsoft\OneDrive",
+                    "$env:AppData\Microsoft\OneDrive",
+                    "$env:ProgramData\Microsoft OneDrive",
+                    "C:\OneDriveTemp"
+                )
+                foreach ($p in $cleanupPaths) {
+                    Remove-Item -Path $p -Recurse -Force -ErrorAction SilentlyContinue
+                }
 
-                # Registry cleanup
-                Remove-Item -Path 'HKCU:\Software\Microsoft\OneDrive'              -Recurse -Force -ErrorAction SilentlyContinue
-                Remove-Item -Path 'HKLM:\SOFTWARE\Microsoft\OneDrive'              -Recurse -Force -ErrorAction SilentlyContinue
-                Remove-Item -Path 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\OneDrive'  -Recurse -Force -ErrorAction SilentlyContinue
+                # Registry cleanup (best-effort)
+                foreach ($regPath in @(
+                    'HKCU:\Software\Microsoft\OneDrive',
+                    'HKLM:\SOFTWARE\Microsoft\OneDrive',
+                    'HKLM:\SOFTWARE\WOW6432Node\Microsoft\OneDrive'
+                )) {
+                    Remove-Item -Path $regPath -Recurse -Force -ErrorAction SilentlyContinue
+                }
                 Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' `
                     -Name 'OneDrive' -ErrorAction SilentlyContinue
 
-                return "[OK] OneDrive removed and cleanup complete"
+                $msg = if ($uninstallRan) { "[OK] OneDrive uninstalled and cleanup complete" } `
+                       else { "[!] OneDrive uninstaller not found; file and registry cleanup completed" }
+                return $msg
             }
         }
     }

--- a/LazyWinAdminModule/Private/Set-ExchangeMailboxPermission.ps1
+++ b/LazyWinAdminModule/Private/Set-ExchangeMailboxPermission.ps1
@@ -18,6 +18,18 @@ function Set-ExchangeMailboxPermission {
         Primary SMTP address or alias of the target shared mailbox (Grant only).
     .PARAMETER User
         UPN of the user to grant permissions to (Grant only).
+    .OUTPUTS
+        System.String — starts with '[OK]' on success or '[!]' on validation error or
+        when no permissions were found (Mirror mode). On unhandled exception returns
+        '[!] Operation failed…'.
+    .EXAMPLE
+        # Copy all shared mailbox permissions from a departing employee to their replacement
+        Set-ExchangeMailboxPermission -Action Mirror `
+            -SourceUser 'alice@contoso.com' -TargetUser 'bob@contoso.com'
+    .EXAMPLE
+        # Grant FullAccess and SendAs on a single shared mailbox to a user
+        Set-ExchangeMailboxPermission -Action Grant `
+            -Mailbox 'helpdesk@contoso.com' -User 'carol@contoso.com'
     #>
     [CmdletBinding()]
     param (
@@ -62,10 +74,10 @@ function Set-ExchangeMailboxPermission {
                 }
             }
 
-            return if ($count -gt 0) {
-                "[OK] Mirrored $count permission(s) from $SourceUser to $TargetUser"
+            if ($count -gt 0) {
+                return "[OK] Mirrored $count permission(s) from $SourceUser to $TargetUser"
             } else {
-                "[!] No shared mailbox permissions found for $SourceUser"
+                return "[!] No shared mailbox permissions found for $SourceUser"
             }
         }
         elseif ($Action -eq 'Grant') {

--- a/LazyWinAdminModule/Private/Set-ExchangeMailboxPermission.ps1
+++ b/LazyWinAdminModule/Private/Set-ExchangeMailboxPermission.ps1
@@ -1,0 +1,89 @@
+function Set-ExchangeMailboxPermission {
+    <#
+    .SYNOPSIS
+        Mirrors or grants mailbox permissions in Exchange Online.
+    .DESCRIPTION
+        Two modes:
+          Mirror — copies every FullAccess and SendAs permission held by SourceUser
+                   across all shared mailboxes to TargetUser.  Used for offboarding /
+                   role handover scenarios.
+          Grant  — grants FullAccess and SendAs on a single named mailbox to a user.
+    .PARAMETER Action
+        'Mirror' or 'Grant'.
+    .PARAMETER SourceUser
+        UPN of the user whose permissions are copied (Mirror only).
+    .PARAMETER TargetUser
+        UPN of the user who receives the copied permissions (Mirror only).
+    .PARAMETER Mailbox
+        Primary SMTP address or alias of the target shared mailbox (Grant only).
+    .PARAMETER User
+        UPN of the user to grant permissions to (Grant only).
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Mirror', 'Grant')]
+        [string]$Action,
+
+        # Mirror parameters
+        [string]$SourceUser,
+        [string]$TargetUser,
+
+        # Grant parameters
+        [string]$Mailbox,
+        [string]$User
+    )
+
+    try {
+        if ($Action -eq 'Mirror') {
+            if (-not $SourceUser -or -not $TargetUser) {
+                return "[!] Mirror requires both SourceUser and TargetUser."
+            }
+
+            $sharedMailboxes = Get-Mailbox -RecipientTypeDetails SharedMailbox -ErrorAction Stop
+            $count = 0
+
+            foreach ($mb in $sharedMailboxes) {
+                $fa = Get-MailboxPermission -Identity $mb.Alias -ErrorAction SilentlyContinue |
+                          Where-Object { $_.User -like $SourceUser -and $_.AccessRights -contains 'FullAccess' }
+                if ($fa) {
+                    Add-MailboxPermission -Identity $mb.Alias -User $TargetUser `
+                        -AccessRights FullAccess -InheritanceType All -AutoMapping:$false `
+                        -ErrorAction SilentlyContinue | Out-Null
+                    $count++
+                }
+
+                $sa = Get-RecipientPermission -Identity $mb.Alias -ErrorAction SilentlyContinue |
+                          Where-Object { $_.Trustee -like $SourceUser -and $_.AccessRights -contains 'SendAs' }
+                if ($sa) {
+                    Add-RecipientPermission -Identity $mb.Alias -Trustee $TargetUser `
+                        -AccessRights SendAs -Confirm:$false -ErrorAction SilentlyContinue | Out-Null
+                    $count++
+                }
+            }
+
+            return if ($count -gt 0) {
+                "[OK] Mirrored $count permission(s) from $SourceUser to $TargetUser"
+            } else {
+                "[!] No shared mailbox permissions found for $SourceUser"
+            }
+        }
+        elseif ($Action -eq 'Grant') {
+            if (-not $Mailbox -or -not $User) {
+                return "[!] Grant requires both Mailbox and User."
+            }
+
+            Add-MailboxPermission -Identity $Mailbox -User $User `
+                -AccessRights FullAccess -InheritanceType All -AutoMapping:$false `
+                -ErrorAction Stop | Out-Null
+            Add-RecipientPermission -Identity $Mailbox -Trustee $User `
+                -AccessRights SendAs -Confirm:$false -ErrorAction Stop | Out-Null
+
+            return "[OK] Granted FullAccess and SendAs on $Mailbox to $User"
+        }
+    }
+    catch {
+        Write-Warning "Exchange permission operation failed: $_"
+        return "[!] Operation failed. Verify Exchange Online connection and target mailbox/user."
+    }
+}

--- a/LazyWinAdminModule/Private/Test-ComputerPort.ps1
+++ b/LazyWinAdminModule/Private/Test-ComputerPort.ps1
@@ -1,23 +1,76 @@
 function Test-ComputerPort {
+    <#
+    .SYNOPSIS
+        Tests whether a TCP port on a remote computer is reachable within a given timeout.
+
+    .DESCRIPTION
+        Creates a TcpClient and initiates a non-blocking connection attempt using
+        BeginConnect / AsyncWaitHandle.WaitOne rather than a synchronous Connect call.
+
+        Why BeginConnect/AsyncWaitHandle instead of Connect():
+            TcpClient.Connect() blocks the calling thread indefinitely until the OS
+            TCP stack either establishes the connection or gives up (which on Windows
+            can take 20+ seconds per RFC 793 retransmission rules). In a runspace-based
+            UI like LazyWinAdmin, blocking the thread freezes the dispatcher. The async
+            pattern lets WaitOne honour -TimeoutMs so the call always returns promptly,
+            keeping the UI responsive. The $waitResult variable captures the Boolean
+            returned by WaitOne (true = signalled within timeout) but the definitive
+            success indicator is TcpClient.Connected, which is checked immediately after.
+
+        Return values are plain strings so they can be displayed directly in the UI
+        without further formatting.
+
+    .PARAMETER ComputerName
+        The hostname or IP address of the target computer. Mandatory.
+        Accepts pipeline input.
+
+    .PARAMETER Port
+        The TCP port number to test. Must be in the range 1–65535.
+        Defaults to 80 (HTTP).
+
+    .PARAMETER TimeoutMs
+        Maximum time in milliseconds to wait for the TCP handshake to complete.
+        Defaults to 2000 (2 seconds). Lower values give faster results on
+        unreachable hosts but may produce false "Closed/Filtered" results on
+        high-latency links.
+
+    .OUTPUTS
+        System.String
+        "Open"            — TCP connection was successfully established.
+        "Closed/Filtered" — Connection was refused or the timeout elapsed with no response.
+        "Error"           — An exception was thrown (e.g. DNS resolution failure).
+
+    .EXAMPLE
+        Test-ComputerPort -ComputerName "SERVER01"
+        Tests whether port 80 is open on SERVER01 (2-second timeout).
+
+    .EXAMPLE
+        Test-ComputerPort -ComputerName "SERVER01" -Port 3389 -TimeoutMs 1000
+        Tests whether RDP (port 3389) is reachable on SERVER01 within 1 second.
+
+    .EXAMPLE
+        "SERVER01","SERVER02" | Test-ComputerPort -Port 445
+        Tests whether SMB (port 445) is open on each piped computer name.
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [string]$ComputerName,
-        
+
         [int]$Port = 80,
-        
+
         [int]$TimeoutMs = 2000
     )
-    
+
     process {
         $tcpClient = $null
         try {
             $tcpClient = New-Object System.Net.Sockets.TcpClient
             $connectTask = $tcpClient.BeginConnect($ComputerName, $Port, $null, $null)
-            
+
             # Non-blocking wait with timeout to prevent hanging the runspace
             $waitResult = $connectTask.AsyncWaitHandle.WaitOne($TimeoutMs, $false)
-            
+
             if ($tcpClient.Connected) {
                 $tcpClient.EndConnect($connectTask)
                 return "Open"

--- a/LazyWinAdminModule/Public/Start-LazyWinAdmin.ps1
+++ b/LazyWinAdminModule/Public/Start-LazyWinAdmin.ps1
@@ -71,6 +71,38 @@ function Start-LazyWinAdmin {
         $btnGetAzureSummary  = $window.FindName("btnGetAzureSummary")
         $lvAzureResources    = $window.FindName("lvAzureResources")
 
+        # Intune Scripts controls
+        $btnGetIntuneScripts         = $window.FindName("btnGetIntuneScripts")
+        $txtIntuneScriptSearch       = $window.FindName("txtIntuneScriptSearch")
+        $txtIntuneScriptDownloadPath = $window.FindName("txtIntuneScriptDownloadPath")
+        $btnDownloadIntuneScripts    = $window.FindName("btnDownloadIntuneScripts")
+        $lvIntuneScripts             = $window.FindName("lvIntuneScripts")
+
+        # Device Compliance controls
+        $btnCheckCompliance  = $window.FindName("btnCheckCompliance")
+        $lvComplianceStatus  = $window.FindName("lvComplianceStatus")
+        $btnFixLocation      = $window.FindName("btnFixLocation")
+        $btnFixOutlookImages = $window.FindName("btnFixOutlookImages")
+        $btnRemoveOneDrive   = $window.FindName("btnRemoveOneDrive")
+        $txtUpdateHoursStart = $window.FindName("txtUpdateHoursStart")
+        $txtUpdateHoursEnd   = $window.FindName("txtUpdateHoursEnd")
+        $btnFixUpdateHours   = $window.FindName("btnFixUpdateHours")
+        $txtComplianceOutput = $window.FindName("txtComplianceOutput")
+
+        # Exchange controls
+        $txtExchangeUpn         = $window.FindName("txtExchangeUpn")
+        $btnConnectExchange     = $window.FindName("btnConnectExchange")
+        $lblExchangeStatus      = $window.FindName("lblExchangeStatus")
+        $btnGetMailboxPerms     = $window.FindName("btnGetMailboxPerms")
+        $txtExchangeViewUser    = $window.FindName("txtExchangeViewUser")
+        $lvMailboxPerms         = $window.FindName("lvMailboxPerms")
+        $txtExchangeSourceUser  = $window.FindName("txtExchangeSourceUser")
+        $txtExchangeTargetUser  = $window.FindName("txtExchangeTargetUser")
+        $btnMirrorMailboxPerms  = $window.FindName("btnMirrorMailboxPerms")
+        $txtExchangeMailbox     = $window.FindName("txtExchangeMailbox")
+        $txtExchangeGrantUser   = $window.FindName("txtExchangeGrantUser")
+        $btnGrantMailboxPerms   = $window.FindName("btnGrantMailboxPerms")
+
         $btnRegRead        = $window.FindName("btnRegRead")
         $btnRegWrite       = $window.FindName("btnRegWrite")
         $btnRegDelete      = $window.FindName("btnRegDelete")
@@ -154,6 +186,8 @@ function Start-LazyWinAdmin {
 
         $SetBusy = {
             param([bool]$isBusy)
+            # Track busy state in SyncHash so event-thread code can read it without touching UI
+            $state.SyncHash.IsBusy = $isBusy
             if ($window.Dispatcher.CheckAccess()) {
                 $pbBusy.IsIndeterminate = $isBusy
                 $lblStatus.Text = if ($isBusy) { "Working..." } else { "Ready" }
@@ -186,6 +220,16 @@ function Start-LazyWinAdmin {
             if ([string]::IsNullOrWhiteSpace($txtComputerName.Text)) {
                 $lblStatus.Text = "[!] No computer name — enter a target in the Computer Name field."
                 $AppendOutput.Invoke("[!] Action blocked: enter a Computer Name before running this action.")
+                return $false
+            }
+            return $true
+        }
+
+        # Checks that Exchange Online is connected.
+        # Must be called before any button handler that calls Exchange cmdlets.
+        $RequireExchangeSession = {
+            if (-not $state.SyncHash.ExchangeConnected) {
+                $lblStatus.Text = "[!] Exchange not connected — use the Exchange › Connection tab first."
                 return $false
             }
             return $true
@@ -229,19 +273,13 @@ function Start-LazyWinAdmin {
         function Invoke-AsyncAction {
             param(
                 [scriptblock]$ScriptBlock,
-                [hashtable]$Parameters         = @{},
+                [hashtable]$Parameters             = @{},
                 [scriptblock]$OnCompleted,
                 [scriptblock]$InitializationScript = {}
             )
 
             $SetBusy.Invoke($true)
 
-            # -RunspacePool is intentionally omitted here.
-            # The RunspacePool object on $state exists for future cross-call CIM session
-            # wiring (see state_lazywinadmin.speq: cim_session PARTIAL) but passing it to
-            # Start-ThreadJob causes a parameter-not-found error in PS 7 because the inbox
-            # stub loaded by auto-discovery does not expose that named parameter.
-            # Start-ThreadJob manages its own internal runspace allocation without it.
             try {
                 $job = Start-ThreadJob `
                            -InitializationScript $InitializationScript `
@@ -252,44 +290,37 @@ function Start-LazyWinAdmin {
                 }
             }
             catch {
-                # Start-ThreadJob itself failed (e.g. runspace quota, bad script reference).
-                # This catch block runs on the UI thread (called from a button click handler),
-                # so update the UI directly — no Dispatcher.Invoke needed.
-                $lblStatus.Text = "[!] Could not start background job: $_"
+                # Runs on UI thread — update directly, no Dispatcher.Invoke needed.
+                $lblStatus.Text         = "[!] Could not start background job: $_"
                 $pbBusy.IsIndeterminate = $false
+                $state.SyncHash.IsBusy  = $false
                 return
             }
 
-            # All values needed inside Dispatcher.Invoke are captured into locals here.
-            # This avoids $Event lifetime issues when the [action] delegate executes
-            # on the WPF UI thread after the event-handler scope has returned.
+            # When the job finishes, enqueue the result for the DispatcherTimer to process
+            # on the WPF UI thread.  This avoids Dispatcher.Invoke/InvokeAsync entirely,
+            # eliminating all re-entrant DispatcherFrame and cross-thread closure issues.
             Register-ObjectEvent -InputObject $job -EventName StateChanged -MessageData @{
                 Job      = $job
-                Window   = $window
+                Queue    = $state.SyncHash.UIQueue
                 Callback = $OnCompleted
                 BusyFn   = $SetBusy
             } -Action {
                 $jobState = $Event.SourceArgs[0].JobStateInfo.State
                 if ($jobState -notin 'Completed', 'Failed', 'Stopped') { return }
 
-                $res       = Receive-Job -Job $Event.MessageData.Job -ErrorAction SilentlyContinue
-                $callback  = $Event.MessageData.Callback
-                $busyFn    = $Event.MessageData.BusyFn
-                $evtWindow = $Event.MessageData.Window
-                $evtJob    = $Event.MessageData.Job
-                $evtSrc    = $EventSubscriber.SourceIdentifier
+                $res    = Receive-Job -Job $Event.MessageData.Job -ErrorAction SilentlyContinue
+                $evtSrc = $EventSubscriber.SourceIdentifier
+                $evtJob = $Event.MessageData.Job
 
-                # InvokeAsync: fire-and-forget marshal to the UI thread.
-                # Non-blocking — does not push a nested DispatcherFrame on the event thread.
-                # Once on the UI thread, $callback and $busyFn hit CheckAccess()=$true
-                # and execute directly, so no further Invoke nesting occurs.
-                $evtWindow.Dispatcher.InvokeAsync([action]{
-                    & $callback $res
-                    $busyFn.Invoke($false)
-                }) | Out-Null
+                $Event.MessageData.Queue.Enqueue([PSCustomObject]@{
+                    Callback = $Event.MessageData.Callback
+                    Result   = $res
+                    BusyFn   = $Event.MessageData.BusyFn
+                })
 
-                Unregister-Event -SourceIdentifier $evtSrc    -ErrorAction SilentlyContinue
-                Remove-Job       -Job $evtJob -Force           -ErrorAction SilentlyContinue
+                Unregister-Event -SourceIdentifier $evtSrc -ErrorAction SilentlyContinue
+                Remove-Job       -Job $evtJob -Force        -ErrorAction SilentlyContinue
             } | Out-Null
         }
 
@@ -644,6 +675,192 @@ function Start-LazyWinAdmin {
                 }
         })
 
+        # --- INTUNE SCRIPTS HANDLERS ---
+        $btnGetIntuneScripts.Add_Click({
+            if (-not ($RequireCloudSession.Invoke())) { return }
+            $search = $txtIntuneScriptSearch.Text
+            Invoke-AsyncAction `
+                -InitializationScript ([scriptblock]::Create(". '$PrivatePath\Get-IntuneManagementScript.ps1'")) `
+                -Parameters  @{ s = $search } `
+                -ScriptBlock { Get-IntuneManagementScript -Search $s } `
+                -OnCompleted {
+                    param($data)
+                    $lvIntuneScripts.Items.Clear()
+                    if ($data) {
+                        $data | ForEach-Object { $lvIntuneScripts.Items.Add($_) }
+                        $AppendOutput.Invoke("[Intune Scripts] $($data.Count) script(s) listed.")
+                    } else {
+                        $AppendOutput.Invoke("[Intune Scripts] No scripts found or not connected to Graph.")
+                    }
+                }
+        })
+
+        $btnDownloadIntuneScripts.Add_Click({
+            if (-not ($RequireCloudSession.Invoke())) { return }
+            $search       = $txtIntuneScriptSearch.Text
+            $downloadPath = $txtIntuneScriptDownloadPath.Text
+            Invoke-AsyncAction `
+                -InitializationScript ([scriptblock]::Create(". '$PrivatePath\Get-IntuneManagementScript.ps1'")) `
+                -Parameters  @{ s = $search; dp = $downloadPath } `
+                -ScriptBlock { Get-IntuneManagementScript -Search $s -DownloadPath $dp } `
+                -OnCompleted {
+                    param($data)
+                    $lvIntuneScripts.Items.Clear()
+                    if ($data) {
+                        $data | ForEach-Object { $lvIntuneScripts.Items.Add($_) }
+                        $AppendOutput.Invoke("[Intune Scripts] $($data.Count) script(s) downloaded to $downloadPath.")
+                    } else {
+                        $AppendOutput.Invoke("[Intune Scripts] No scripts found or not connected to Graph.")
+                    }
+                }
+        })
+
+        # --- DEVICE COMPLIANCE HANDLERS ---
+        $btnCheckCompliance.Add_Click({
+            Invoke-AsyncAction `
+                -InitializationScript ([scriptblock]::Create(". '$PrivatePath\Get-DeviceComplianceStatus.ps1'")) `
+                -ScriptBlock { Get-DeviceComplianceStatus } `
+                -OnCompleted {
+                    param($data)
+                    $lvComplianceStatus.Items.Clear()
+                    $data | ForEach-Object { $lvComplianceStatus.Items.Add($_) }
+                }
+        })
+
+        $btnFixLocation.Add_Click({
+            Invoke-AsyncAction `
+                -InitializationScript ([scriptblock]::Create(". '$PrivatePath\Set-DeviceComplianceItem.ps1'")) `
+                -ScriptBlock { Set-DeviceComplianceItem -Item 'LocationServices' } `
+                -OnCompleted {
+                    param($res)
+                    $txtComplianceOutput.Text = $res
+                    if ($res -match '^Error:') { $AdminHint.Invoke($env:COMPUTERNAME) }
+                }
+        })
+
+        $btnFixOutlookImages.Add_Click({
+            Invoke-AsyncAction `
+                -InitializationScript ([scriptblock]::Create(". '$PrivatePath\Set-DeviceComplianceItem.ps1'")) `
+                -ScriptBlock { Set-DeviceComplianceItem -Item 'OutlookExternalImages' } `
+                -OnCompleted {
+                    param($res)
+                    $txtComplianceOutput.Text = $res
+                }
+        })
+
+        $btnRemoveOneDrive.Add_Click({
+            Invoke-AsyncAction `
+                -InitializationScript ([scriptblock]::Create(". '$PrivatePath\Set-DeviceComplianceItem.ps1'")) `
+                -ScriptBlock { Set-DeviceComplianceItem -Item 'RemoveOneDrive' } `
+                -OnCompleted {
+                    param($res)
+                    $txtComplianceOutput.Text = $res
+                    if ($res -match '^Error:') { $AdminHint.Invoke($env:COMPUTERNAME) }
+                }
+        })
+
+        $btnFixUpdateHours.Add_Click({
+            $startHour = 0
+            $endHour   = 0
+            if (-not [int]::TryParse($txtUpdateHoursStart.Text, [ref]$startHour) -or
+                -not [int]::TryParse($txtUpdateHoursEnd.Text,   [ref]$endHour)   -or
+                $startHour -lt 0 -or $startHour -gt 23 -or
+                $endHour   -lt 0 -or $endHour   -gt 23) {
+                $txtComplianceOutput.Text = "[!] Start and End hours must be integers between 0 and 23."
+                return
+            }
+            Invoke-AsyncAction `
+                -InitializationScript ([scriptblock]::Create(". '$PrivatePath\Set-DeviceComplianceItem.ps1'")) `
+                -Parameters  @{ sh = $startHour; eh = $endHour } `
+                -ScriptBlock { Set-DeviceComplianceItem -Item 'WindowsUpdateActiveHours' -ActiveHoursStart $sh -ActiveHoursEnd $eh } `
+                -OnCompleted {
+                    param($res)
+                    $txtComplianceOutput.Text = $res
+                    if ($res -match '^Error:') { $AdminHint.Invoke($env:COMPUTERNAME) }
+                }
+        })
+
+        # --- EXCHANGE HANDLERS ---
+        $btnConnectExchange.Add_Click({
+            $upn = $txtExchangeUpn.Text
+            Invoke-AsyncAction `
+                -InitializationScript ([scriptblock]::Create(". '$PrivatePath\Connect-ExchangeSession.ps1'")) `
+                -Parameters  @{ u = $upn } `
+                -ScriptBlock { Connect-ExchangeSession -UserPrincipalName $u } `
+                -OnCompleted {
+                    param($res)
+                    $connected = $res -match '^\[OK\]'
+                    $state.SyncHash.ExchangeConnected = $connected
+                    $lblExchangeStatus.Text       = $res
+                    $lblExchangeStatus.Foreground  = if ($connected) {
+                        [System.Windows.Media.Brushes]::Green
+                    } else {
+                        [System.Windows.Media.Brushes]::Red
+                    }
+                    $lblStatus.Text = if ($connected) { "Exchange: connected" } else { "Exchange: not connected" }
+                }
+        })
+
+        $btnGetMailboxPerms.Add_Click({
+            if (-not ($RequireExchangeSession.Invoke())) { return }
+            $upn = $txtExchangeViewUser.Text
+            if ([string]::IsNullOrWhiteSpace($upn)) {
+                $lblStatus.Text = "[!] Enter a User Principal Name to look up."
+                return
+            }
+            Invoke-AsyncAction `
+                -InitializationScript ([scriptblock]::Create(". '$PrivatePath\Get-ExchangeMailboxPermission.ps1'")) `
+                -Parameters  @{ u = $upn } `
+                -ScriptBlock { Get-ExchangeMailboxPermission -UserPrincipalName $u } `
+                -OnCompleted {
+                    param($data)
+                    $lvMailboxPerms.Items.Clear()
+                    if ($data) {
+                        $data | ForEach-Object { $lvMailboxPerms.Items.Add($_) }
+                    } else {
+                        $AppendOutput.Invoke("[Exchange] No shared mailbox permissions found for $upn.")
+                    }
+                }
+        })
+
+        $btnMirrorMailboxPerms.Add_Click({
+            if (-not ($RequireExchangeSession.Invoke())) { return }
+            $src = $txtExchangeSourceUser.Text
+            $tgt = $txtExchangeTargetUser.Text
+            if ([string]::IsNullOrWhiteSpace($src) -or [string]::IsNullOrWhiteSpace($tgt)) {
+                $lblStatus.Text = "[!] Enter both source and target UPNs for mirror."
+                return
+            }
+            Invoke-AsyncAction `
+                -InitializationScript ([scriptblock]::Create(". '$PrivatePath\Set-ExchangeMailboxPermission.ps1'")) `
+                -Parameters  @{ src = $src; tgt = $tgt } `
+                -ScriptBlock { Set-ExchangeMailboxPermission -Action Mirror -SourceUser $src -TargetUser $tgt } `
+                -OnCompleted {
+                    param($res)
+                    $AppendOutput.Invoke("[Exchange Mirror] $res")
+                    $lblStatus.Text = $res
+                }
+        })
+
+        $btnGrantMailboxPerms.Add_Click({
+            if (-not ($RequireExchangeSession.Invoke())) { return }
+            $mb   = $txtExchangeMailbox.Text
+            $user = $txtExchangeGrantUser.Text
+            if ([string]::IsNullOrWhiteSpace($mb) -or [string]::IsNullOrWhiteSpace($user)) {
+                $lblStatus.Text = "[!] Enter both a mailbox address and a user UPN."
+                return
+            }
+            Invoke-AsyncAction `
+                -InitializationScript ([scriptblock]::Create(". '$PrivatePath\Set-ExchangeMailboxPermission.ps1'")) `
+                -Parameters  @{ mb = $mb; u = $user } `
+                -ScriptBlock { Set-ExchangeMailboxPermission -Action Grant -Mailbox $mb -User $u } `
+                -OnCompleted {
+                    param($res)
+                    $AppendOutput.Invoke("[Exchange Grant] $res")
+                    $lblStatus.Text = $res
+                }
+        })
+
         # --- CLOUD AUTH HANDLER ---
         $btnCloudLogin.Add_Click({
             Invoke-AsyncAction `
@@ -689,6 +906,22 @@ function Start-LazyWinAdmin {
                     $lblStatus.Text = if ($connected) { "Cloud: connected" } else { "Cloud: not connected" }
                 }
         })
+
+        # DispatcherTimer — drains the UI callback queue on the WPF thread every 50 ms.
+        # Background jobs enqueue their results via Register-ObjectEvent actions.
+        # The timer dequeues and calls OnCompleted callbacks here, on the UI thread,
+        # with full access to all WPF controls — no Dispatcher.Invoke needed in callbacks.
+        $uiTimer          = [System.Windows.Threading.DispatcherTimer]::new()
+        $uiTimer.Interval = [TimeSpan]::FromMilliseconds(50)
+        $uiTimer.Add_Tick({
+            $workItem = $null
+            while ($state.SyncHash.UIQueue.TryDequeue([ref]$workItem)) {
+                try   { & $workItem.Callback $workItem.Result }
+                catch { $AppendOutput.Invoke("[!] UI callback error: $_") }
+                finally { $workItem.BusyFn.Invoke($false) }
+            }
+        })
+        $uiTimer.Start()
 
         $window.ShowDialog() | Out-Null
     }

--- a/LazyWinAdminModule/Tests/Functions.Tests.ps1
+++ b/LazyWinAdminModule/Tests/Functions.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.4
+﻿#Requires -Version 7.4
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 <#
 .SYNOPSIS
@@ -1273,6 +1273,1104 @@ Describe 'Set-ComputerRDP' {
             Mock Remove-CimSession { }
             Set-ComputerRDP -ComputerName 'localhost' -Enabled $false | Out-Null
             Should -Invoke Remove-CimSession -Times 1 -Exactly
+        }
+    }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+Describe 'Test-ComputerPort' {
+
+    Context 'Input validation' {
+
+        It 'Throws on missing ComputerName (mandatory parameter)' {
+            # ComputerName has [Parameter(Mandatory=$true)] — PowerShell will throw at binding
+            { Test-ComputerPort -Port 80 } | Should -Throw
+        }
+
+        It 'Accepts default port 80 without error when New-Object throws' {
+            # Even with a failing TcpClient, specifying no Port must not throw a binding error.
+            Mock New-Object { throw 'Simulated socket failure' } -ParameterFilter {
+                $TypeName -eq 'System.Net.Sockets.TcpClient'
+            }
+            $result = Test-ComputerPort -ComputerName 'localhost'
+            $result | Should -Be 'Error'
+        }
+    }
+
+    Context 'Error path — New-Object throws (e.g. DNS failure or socket error)' {
+
+        BeforeAll {
+            Mock New-Object { throw 'Simulated socket failure' } -ParameterFilter {
+                $TypeName -eq 'System.Net.Sockets.TcpClient'
+            }
+        }
+
+        It 'Returns "Error" when TcpClient creation throws' {
+            $result = Test-ComputerPort -ComputerName 'unreachable.invalid' -Port 80
+            $result | Should -Be 'Error'
+        }
+
+        It 'Return value is the string "Error" (not $null)' {
+            $result = Test-ComputerPort -ComputerName 'unreachable.invalid' -Port 80
+            $result | Should -BeOfType [string]
+            $result | Should -Be 'Error'
+        }
+    }
+
+    Context 'Return value is always one of three expected strings' {
+
+        It 'Returns one of "Open", "Closed/Filtered", or "Error" for an unreachable host with a short timeout' {
+            # Use a guaranteed-unreachable address and a minimal timeout to get a fast result.
+            # We cannot control which of the three values is returned, but it must be one of them.
+            $result = Test-ComputerPort -ComputerName '192.0.2.1' -Port 9 -TimeoutMs 100
+            $result | Should -BeIn @('Open', 'Closed/Filtered', 'Error')
+        }
+
+        It 'Returns a non-null string' {
+            $result = Test-ComputerPort -ComputerName '192.0.2.1' -Port 9 -TimeoutMs 100
+            $result | Should -Not -BeNullOrEmpty
+        }
+    }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+Describe 'Connect-ModernCloud (additional guards)' {
+    # The basic happy-path and connection-exception tests are already covered in
+    # the existing Connect-ModernCloud Describe block above.  This block adds the
+    # guard tests specified in the feature matrix.
+
+    Context 'Guard — Interactive and ClientId both specified' {
+
+        It 'Returns "[!]" string when both -Interactive and -ClientId are provided' {
+            $result = Connect-ModernCloud -Interactive -ClientId 'some-client-id'
+            $result | Should -Match '^\[!\]'
+        }
+
+        It 'Returns the exact guard message' {
+            $result = Connect-ModernCloud -Interactive -ClientId 'some-client-id'
+            $result | Should -Be '[!] Specify either -Interactive or -ClientId/-ClientSecret, not both.'
+        }
+
+        It 'Does NOT call Connect-MgGraph when the guard fires' {
+            Mock Connect-MgGraph { }
+            Connect-ModernCloud -Interactive -ClientId 'some-client-id' | Out-Null
+            Should -Invoke Connect-MgGraph -Times 0
+        }
+    }
+
+    Context 'Guard — Service principal mode missing TenantId' {
+
+        It 'Returns "[!]" string when TenantId is absent' {
+            $secret = ConvertTo-SecureString 'dummy' -AsPlainText -Force
+            $result = Connect-ModernCloud -ClientId 'cid' -ClientSecret $secret
+            $result | Should -Match '^\[!\]'
+        }
+
+        It 'Returns the SP-mode guard message when TenantId is absent' {
+            $secret = ConvertTo-SecureString 'dummy' -AsPlainText -Force
+            $result = Connect-ModernCloud -ClientId 'cid' -ClientSecret $secret
+            $result | Should -Be '[!] Service principal mode requires -TenantId, -ClientId, and -ClientSecret.'
+        }
+    }
+
+    Context 'Guard — invalid TenantId format' {
+
+        It 'Returns "[!]" string for a TenantId that is not a GUID or onmicrosoft.com domain' {
+            $secret = ConvertTo-SecureString 'dummy' -AsPlainText -Force
+            $result = Connect-ModernCloud -TenantId 'not-valid-format' -ClientId 'cid' -ClientSecret $secret
+            $result | Should -Match '^\[!\]'
+        }
+
+        It 'Returns the TenantId format guard message' {
+            $secret = ConvertTo-SecureString 'dummy' -AsPlainText -Force
+            $result = Connect-ModernCloud -TenantId 'not-valid-format' -ClientId 'cid' -ClientSecret $secret
+            $result | Should -Be '[!] TenantId must be a GUID or an onmicrosoft.com domain name.'
+        }
+    }
+
+    Context 'Guard — valid GUID TenantId passes the format check' {
+
+        It 'Does NOT return the TenantId format guard message for a valid GUID' {
+            # The format guard fires only for non-GUID/non-onmicrosoft.com values.
+            # A valid GUID must not trigger it — the function proceeds past the guard
+            # (it may still fail to connect, but that is a different [!] message).
+            $secret = ConvertTo-SecureString 'dummy' -AsPlainText -Force
+            $result = Connect-ModernCloud -TenantId '12345678-1234-1234-1234-123456789012' -ClientId 'cid' -ClientSecret $secret
+            $result | Should -Not -Be '[!] TenantId must be a GUID or an onmicrosoft.com domain name.'
+        }
+    }
+
+    Context 'Guard — valid onmicrosoft.com TenantId passes the format check' {
+
+        It 'Does NOT return the TenantId format guard message for a valid onmicrosoft.com domain' {
+            $secret = ConvertTo-SecureString 'dummy' -AsPlainText -Force
+            $result = Connect-ModernCloud -TenantId 'contoso.onmicrosoft.com' -ClientId 'cid' -ClientSecret $secret
+            $result | Should -Not -Be '[!] TenantId must be a GUID or an onmicrosoft.com domain name.'
+        }
+    }
+
+    Context 'Happy path Interactive — mock Connect-MgGraph and Get-MgContext' {
+
+        BeforeAll {
+            Mock Connect-MgGraph { }
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 'abc-123'; Account = 'user@test.com' } }
+        }
+
+        It 'Returns "[OK]" string' {
+            $result = Connect-ModernCloud -Interactive
+            $result | Should -Match '^\[OK\]'
+        }
+
+        It 'Calls Connect-MgGraph exactly once' {
+            Connect-ModernCloud -Interactive | Out-Null
+            Should -Invoke Connect-MgGraph -Times 1 -Exactly
+        }
+
+        It 'Calls Get-MgContext exactly once' {
+            Connect-ModernCloud -Interactive | Out-Null
+            Should -Invoke Get-MgContext -Times 1 -Exactly
+        }
+    }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+Describe 'Connect-ExchangeSession' {
+
+    BeforeAll {
+        # Ensure Exchange cmdlets exist as stubs so Pester can mock them regardless of
+        # whether ExchangeOnlineManagement is installed on the test runner.
+        if (-not (Get-Command Connect-ExchangeOnline   -ErrorAction SilentlyContinue)) {
+            function Connect-ExchangeOnline   { param([hashtable]$params) }
+        }
+        if (-not (Get-Command Get-OrganizationConfig   -ErrorAction SilentlyContinue)) {
+            function Get-OrganizationConfig   { }
+        }
+    }
+
+    Context 'Guard — ExchangeOnlineManagement module not found' {
+
+        BeforeAll {
+            Mock Get-Module { return $null } -ParameterFilter {
+                $Name -eq 'ExchangeOnlineManagement' -and $ListAvailable
+            }
+        }
+
+        It 'Returns "[!] ExchangeOnlineManagement module not found" string' {
+            $result = Connect-ExchangeSession
+            $result | Should -Match '^\[!\] ExchangeOnlineManagement module not found'
+        }
+
+        It 'Does NOT call Import-Module when the module guard fires' {
+            Mock Import-Module { }
+            Connect-ExchangeSession | Out-Null
+            Should -Invoke Import-Module -Times 0
+        }
+    }
+
+    Context 'Happy path — module present, connection succeeds' {
+
+        BeforeAll {
+            Mock Get-Module { [PSCustomObject]@{ Name = 'ExchangeOnlineManagement' } } -ParameterFilter {
+                $Name -eq 'ExchangeOnlineManagement' -and $ListAvailable
+            }
+            Mock Import-Module { }
+            Mock Connect-ExchangeOnline { }
+            Mock Get-OrganizationConfig { [PSCustomObject]@{ DisplayName = 'Contoso' } }
+        }
+
+        It 'Returns "[OK]" string' {
+            $result = Connect-ExchangeSession
+            $result | Should -Match '^\[OK\]'
+        }
+
+        It 'Return value contains the organisation display name' {
+            $result = Connect-ExchangeSession
+            $result | Should -Match 'Contoso'
+        }
+
+        It 'Calls Connect-ExchangeOnline exactly once' {
+            Connect-ExchangeSession | Out-Null
+            Should -Invoke Connect-ExchangeOnline -Times 1 -Exactly
+        }
+
+        It 'Calls Get-OrganizationConfig exactly once' {
+            Connect-ExchangeSession | Out-Null
+            Should -Invoke Get-OrganizationConfig -Times 1 -Exactly
+        }
+
+        It 'Passes UserPrincipalName to Connect-ExchangeOnline when provided' {
+            $script:CapturedConnectEXOParams = $null
+            Mock Connect-ExchangeOnline {
+                param([switch]$ShowBanner, [string]$UserPrincipalName, [string]$ErrorAction)
+                $script:CapturedConnectEXOParams = $PSBoundParameters
+            }
+            Connect-ExchangeSession -UserPrincipalName 'admin@contoso.com' | Out-Null
+            $script:CapturedConnectEXOParams.ContainsKey('UserPrincipalName') | Should -BeTrue
+        }
+    }
+
+    Context 'Error path — Connect-ExchangeOnline throws' {
+
+        BeforeAll {
+            Mock Get-Module { [PSCustomObject]@{ Name = 'ExchangeOnlineManagement' } } -ParameterFilter {
+                $Name -eq 'ExchangeOnlineManagement' -and $ListAvailable
+            }
+            Mock Import-Module { }
+            Mock Connect-ExchangeOnline { throw 'Authentication failed' }
+        }
+
+        It 'Returns "[!]" string on connection failure' {
+            $result = Connect-ExchangeSession
+            $result | Should -Match '^\[!\]'
+        }
+
+        It 'Does NOT surface exception text in the return value' {
+            $result = Connect-ExchangeSession
+            $result | Should -Not -Match 'Authentication failed'
+            $result | Should -Not -Match 'Exception'
+        }
+    }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+Describe 'Get-DeviceComplianceStatus' {
+
+    Context 'Result list shape' {
+
+        BeforeAll {
+            Mock Get-ItemProperty { $null }
+            Mock Test-Path { $false }
+            Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Windows 10 Pro' } }
+        }
+
+        It 'Returns exactly 5 items' {
+            $result = Get-DeviceComplianceStatus
+            @($result).Count | Should -Be 5
+        }
+
+        It 'Every item has Item, Status, and Description properties' {
+            $result = Get-DeviceComplianceStatus
+            foreach ($item in $result) {
+                $item.PSObject.Properties.Name | Should -Contain 'Item'
+                $item.PSObject.Properties.Name | Should -Contain 'Status'
+                $item.PSObject.Properties.Name | Should -Contain 'Description'
+            }
+        }
+
+        It 'Item names are the expected five labels' {
+            $result  = Get-DeviceComplianceStatus
+            $names   = $result | ForEach-Object { $_.Item }
+            $names   | Should -Contain 'Location Services'
+            $names   | Should -Contain 'OneDrive'
+            $names   | Should -Contain 'Outlook External Images'
+            $names   | Should -Contain 'Windows Update Active Hours'
+            $names   | Should -Contain 'Unified Write Filter'
+        }
+    }
+
+    Context 'Location Services — Compliant when policy not blocked, service cfg=1, consent=Allow' {
+
+        BeforeAll {
+            Mock Get-ItemProperty {
+                param($Path)
+                switch -Wildcard ($Path) {
+                    '*LocationAndSensors*' {
+                        [PSCustomObject]@{ DisableLocation = 0; DisableWindowsLocationProvider = 0; DisableSensors = 0 }
+                    }
+                    '*lfsvc*' {
+                        [PSCustomObject]@{ Status = 1 }
+                    }
+                    '*ConsentStore\location*' {
+                        [PSCustomObject]@{ Value = 'Allow' }
+                    }
+                    default { $null }
+                }
+            }
+            Mock Test-Path { $false }
+            Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Windows 10 Pro' } }
+        }
+
+        It 'Location Services Status is Compliant' {
+            $result = Get-DeviceComplianceStatus
+            $item   = $result | Where-Object { $_.Item -eq 'Location Services' }
+            $item.Status | Should -Be 'Compliant'
+        }
+    }
+
+    Context 'Location Services — Non-Compliant when DisableLocation = 1' {
+
+        BeforeAll {
+            Mock Get-ItemProperty {
+                param($Path)
+                switch -Wildcard ($Path) {
+                    '*LocationAndSensors*' {
+                        [PSCustomObject]@{ DisableLocation = 1; DisableWindowsLocationProvider = 0; DisableSensors = 0 }
+                    }
+                    default { $null }
+                }
+            }
+            Mock Test-Path { $false }
+            Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Windows 10 Pro' } }
+        }
+
+        It 'Location Services Status is Non-Compliant when policy is locked' {
+            $result = Get-DeviceComplianceStatus
+            $item   = $result | Where-Object { $_.Item -eq 'Location Services' }
+            $item.Status | Should -Be 'Non-Compliant'
+        }
+    }
+
+    Context 'OneDrive — Installed when setup exe found' {
+
+        BeforeAll {
+            Mock Get-ItemProperty { $null }
+            Mock Test-Path {
+                param($Path)
+                # Return $true for the System32 OneDriveSetup path
+                $Path -like '*System32*OneDriveSetup.exe*'
+            }
+            Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Windows 10 Pro' } }
+        }
+
+        It 'OneDrive Status is Installed when System32 setup exe exists' {
+            $result = Get-DeviceComplianceStatus
+            $item   = $result | Where-Object { $_.Item -eq 'OneDrive' }
+            $item.Status | Should -Be 'Installed'
+        }
+    }
+
+    Context 'OneDrive — Not Installed when no setup exe found' {
+
+        BeforeAll {
+            Mock Get-ItemProperty { $null }
+            Mock Test-Path { $false }
+            Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Windows 10 Pro' } }
+        }
+
+        It 'OneDrive Status is Not Installed when no exe found' {
+            $result = Get-DeviceComplianceStatus
+            $item   = $result | Where-Object { $_.Item -eq 'OneDrive' }
+            $item.Status | Should -Be 'Not Installed'
+        }
+    }
+
+    Context 'Outlook External Images — various BlockExtContent values' {
+
+        It 'Status is Compliant when BlockExtContent = 0' {
+            Mock Get-ItemProperty {
+                param($Path)
+                if ($Path -like '*Outlook*Mail*') { [PSCustomObject]@{ BlockExtContent = 0 } }
+                else { $null }
+            }
+            Mock Test-Path { $false }
+            Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Windows 10 Pro' } }
+
+            $result = Get-DeviceComplianceStatus
+            $item   = $result | Where-Object { $_.Item -eq 'Outlook External Images' }
+            $item.Status | Should -Be 'Compliant'
+        }
+
+        It 'Status is Blocked when BlockExtContent = 1' {
+            Mock Get-ItemProperty {
+                param($Path)
+                if ($Path -like '*Outlook*Mail*') { [PSCustomObject]@{ BlockExtContent = 1 } }
+                else { $null }
+            }
+            Mock Test-Path { $false }
+            Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Windows 10 Pro' } }
+
+            $result = Get-DeviceComplianceStatus
+            $item   = $result | Where-Object { $_.Item -eq 'Outlook External Images' }
+            $item.Status | Should -Be 'Blocked'
+        }
+
+        It 'Status is Not Configured when BlockExtContent key is absent' {
+            Mock Get-ItemProperty { $null }
+            Mock Test-Path { $false }
+            Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Windows 10 Pro' } }
+
+            $result = Get-DeviceComplianceStatus
+            $item   = $result | Where-Object { $_.Item -eq 'Outlook External Images' }
+            $item.Status | Should -Be 'Not Configured'
+        }
+    }
+
+    Context 'Windows Update Active Hours' {
+
+        It 'Status is Configured when both ActiveHoursStart and ActiveHoursEnd are present' {
+            Mock Get-ItemProperty {
+                param($Path)
+                if ($Path -like '*WindowsUpdate*') { [PSCustomObject]@{ ActiveHoursStart = 8; ActiveHoursEnd = 18 } }
+                else { $null }
+            }
+            Mock Test-Path { $false }
+            Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Windows 10 Pro' } }
+
+            $result = Get-DeviceComplianceStatus
+            $item   = $result | Where-Object { $_.Item -eq 'Windows Update Active Hours' }
+            $item.Status | Should -Be 'Configured'
+        }
+
+        It 'Status is Not Configured when active hours keys are absent' {
+            Mock Get-ItemProperty { $null }
+            Mock Test-Path { $false }
+            Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Windows 10 Pro' } }
+
+            $result = Get-DeviceComplianceStatus
+            $item   = $result | Where-Object { $_.Item -eq 'Windows Update Active Hours' }
+            $item.Status | Should -Be 'Not Configured'
+        }
+    }
+
+    Context 'Unified Write Filter — N/A on non-Enterprise OS' {
+
+        BeforeAll {
+            Mock Get-ItemProperty { $null }
+            Mock Test-Path { $false }
+            Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Windows 10 Pro' } }
+        }
+
+        It 'UWF Status is N/A on non-Enterprise Windows' {
+            $result = Get-DeviceComplianceStatus
+            $item   = $result | Where-Object { $_.Item -eq 'Unified Write Filter' }
+            $item.Status | Should -Be 'N/A'
+        }
+    }
+
+    Context 'Error resilience — if one item throws, others still return results' {
+
+        BeforeAll {
+            # Make Get-ItemProperty throw to induce errors in the registry-reading items,
+            # but Get-CimInstance must still succeed for UWF item.
+            Mock Get-ItemProperty { throw 'Simulated registry failure' }
+            Mock Test-Path { throw 'Simulated filesystem failure' }
+            Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Windows 10 Pro' } }
+        }
+
+        It 'Still returns exactly 5 items even when individual checks throw' {
+            $result = Get-DeviceComplianceStatus
+            @($result).Count | Should -Be 5
+        }
+
+        It 'Failed items report Status "Error"' {
+            $result      = Get-DeviceComplianceStatus
+            $errorItems  = $result | Where-Object { $_.Status -eq 'Error' }
+            @($errorItems).Count | Should -BeGreaterThan 0
+        }
+    }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+Describe 'Set-DeviceComplianceItem' {
+
+    Context 'LocationServices — happy path' {
+
+        BeforeAll {
+            Mock Set-ItemProperty { }
+            Mock New-Item { [PSCustomObject]@{ PSPath = 'HKLM:\...' } }
+            Mock Test-Path { $true }   # paths already exist → New-Item not called
+            Mock Restart-Service { }
+            # Mock the HKEY_USERS enumeration used in the foreach loop
+            Mock Get-ChildItem { @() } -ParameterFilter { $Path -like 'Registry::HKEY_USERS' }
+        }
+
+        It 'Returns "[OK]" string for LocationServices' {
+            $result = Set-DeviceComplianceItem -Item 'LocationServices'
+            $result | Should -Match '^\[OK\]'
+        }
+
+        It 'Calls Set-ItemProperty at least once for LocationServices' {
+            Set-DeviceComplianceItem -Item 'LocationServices' | Out-Null
+            Should -Invoke Set-ItemProperty -Times 1
+        }
+
+        It 'Calls Restart-Service for lfsvc' {
+            Set-DeviceComplianceItem -Item 'LocationServices' | Out-Null
+            Should -Invoke Restart-Service -Times 1 -Exactly -ParameterFilter { $Name -eq 'lfsvc' }
+        }
+    }
+
+    Context 'OutlookExternalImages — happy path' {
+
+        BeforeAll {
+            Mock Set-ItemProperty { }
+            Mock New-Item { [PSCustomObject]@{ PSPath = 'HKCU:\...' } }
+            Mock Test-Path { $true }
+        }
+
+        It 'Returns "[OK]" string for OutlookExternalImages' {
+            $result = Set-DeviceComplianceItem -Item 'OutlookExternalImages'
+            $result | Should -Match '^\[OK\]'
+        }
+
+        It 'Calls Set-ItemProperty with BlockExtContent = 0' {
+            $script:CapturedOEIValue = $null
+            Mock Set-ItemProperty {
+                param($Path, $Name, $Value)
+                if ($Name -eq 'BlockExtContent') { $script:CapturedOEIValue = $Value }
+            }
+            Set-DeviceComplianceItem -Item 'OutlookExternalImages' | Out-Null
+            $script:CapturedOEIValue | Should -Be 0
+        }
+    }
+
+    Context 'WindowsUpdateActiveHours — happy path' {
+
+        BeforeAll {
+            Mock Set-ItemProperty { }
+            Mock New-Item { [PSCustomObject]@{ PSPath = 'HKLM:\...' } }
+            Mock Test-Path { $true }
+        }
+
+        It 'Returns "[OK]" string for WindowsUpdateActiveHours' {
+            $result = Set-DeviceComplianceItem -Item 'WindowsUpdateActiveHours' -ActiveHoursStart 8 -ActiveHoursEnd 18
+            $result | Should -Match '^\[OK\]'
+        }
+
+        It 'Return value includes the configured hours' {
+            $result = Set-DeviceComplianceItem -Item 'WindowsUpdateActiveHours' -ActiveHoursStart 9 -ActiveHoursEnd 17
+            $result | Should -Match '9:00'
+            $result | Should -Match '17:00'
+        }
+
+        It 'Calls Set-ItemProperty for ActiveHoursStart and ActiveHoursEnd' {
+            Set-DeviceComplianceItem -Item 'WindowsUpdateActiveHours' -ActiveHoursStart 8 -ActiveHoursEnd 18 | Out-Null
+            Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Name -eq 'ActiveHoursStart' }
+            Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Name -eq 'ActiveHoursEnd' }
+        }
+    }
+
+    Context 'WindowsUpdateActiveHours — guard: start equals end' {
+
+        BeforeAll {
+            Mock Set-ItemProperty { }
+            Mock Test-Path { $true }
+        }
+
+        It 'Returns "[!]" string when ActiveHoursStart equals ActiveHoursEnd' {
+            $result = Set-DeviceComplianceItem -Item 'WindowsUpdateActiveHours' -ActiveHoursStart 12 -ActiveHoursEnd 12
+            $result | Should -Match '^\[!\]'
+        }
+
+        It 'Does NOT call Set-ItemProperty when start equals end' {
+            Set-DeviceComplianceItem -Item 'WindowsUpdateActiveHours' -ActiveHoursStart 12 -ActiveHoursEnd 12 | Out-Null
+            Should -Invoke Set-ItemProperty -Times 0
+        }
+    }
+
+    Context 'RemoveOneDrive — no installer found (cleanup-only path)' {
+
+        BeforeAll {
+            Mock Get-Process { }
+            Mock Stop-Process { }
+            Mock Test-Path { $false }   # setup exe not found → uninstallRan stays $false
+            Mock Start-Process { [PSCustomObject]@{ ExitCode = 0 } }
+            Mock Remove-Item { }
+            Mock Remove-ItemProperty { }
+        }
+
+        It 'Returns "[!] OneDrive uninstaller not found..." string when no setup exe is present' {
+            # When Test-Path returns $false for both setup exe paths, $uninstallRan stays $false
+            # and the function returns the not-found cleanup message (prefixed with [!]).
+            $result = Set-DeviceComplianceItem -Item 'RemoveOneDrive'
+            $result | Should -Match '^\[!\] OneDrive uninstaller not found'
+        }
+
+        It 'Calls Get-Process to find the OneDrive process' {
+            Set-DeviceComplianceItem -Item 'RemoveOneDrive' | Out-Null
+            Should -Invoke Get-Process -Times 1 -ParameterFilter { $Name -eq 'OneDrive' }
+        }
+    }
+
+    Context 'RemoveOneDrive — installer found and runs successfully' {
+
+        BeforeAll {
+            Mock Get-Process { }
+            Mock Stop-Process { }
+            # Return $true only for the System32 path so Start-Process is called exactly once.
+            Mock Test-Path {
+                param($Path)
+                $Path -like '*System32*OneDriveSetup.exe*'
+            }
+            Mock Start-Process { [PSCustomObject]@{ ExitCode = 0 } }
+            Mock Remove-Item { }
+            Mock Remove-ItemProperty { }
+        }
+
+        It 'Returns "[OK]" string when uninstaller runs and exits cleanly' {
+            $result = Set-DeviceComplianceItem -Item 'RemoveOneDrive'
+            $result | Should -Match '^\[OK\]'
+        }
+
+        It 'Calls Start-Process exactly once to run the uninstaller' {
+            Set-DeviceComplianceItem -Item 'RemoveOneDrive' | Out-Null
+            Should -Invoke Start-Process -Times 1 -Exactly
+        }
+    }
+
+    Context 'Input validation' {
+
+        It 'Throws on an invalid Item value (ValidateSet enforcement)' {
+            { Set-DeviceComplianceItem -Item 'InvalidItem' } | Should -Throw
+        }
+
+        It 'Throws when ActiveHoursStart is out of range (24)' {
+            { Set-DeviceComplianceItem -Item 'WindowsUpdateActiveHours' -ActiveHoursStart 24 } | Should -Throw
+        }
+
+        It 'Throws when ActiveHoursEnd is out of range (24)' {
+            { Set-DeviceComplianceItem -Item 'WindowsUpdateActiveHours' -ActiveHoursEnd 24 } | Should -Throw
+        }
+    }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+Describe 'Get-ExchangeMailboxPermission' {
+
+    BeforeAll {
+        # Stub Exchange cmdlets so Pester can mock them on systems without the module.
+        if (-not (Get-Command Get-Mailbox            -ErrorAction SilentlyContinue)) {
+            function Get-Mailbox            { param([string]$RecipientTypeDetails, [string]$ErrorAction) }
+        }
+        if (-not (Get-Command Get-MailboxPermission  -ErrorAction SilentlyContinue)) {
+            function Get-MailboxPermission  { param([string]$Identity, [string]$ErrorAction) }
+        }
+        if (-not (Get-Command Get-RecipientPermission -ErrorAction SilentlyContinue)) {
+            function Get-RecipientPermission { param([string]$Identity, [string]$ErrorAction) }
+        }
+    }
+
+    Context 'Happy path — user holds FullAccess on first mailbox and SendAs on second' {
+
+        BeforeAll {
+            Mock Get-Mailbox {
+                @(
+                    [PSCustomObject]@{ Alias = 'mb1'; PrimarySmtpAddress = 'mb1@contoso.com'; DisplayName = 'Mailbox 1' },
+                    [PSCustomObject]@{ Alias = 'mb2'; PrimarySmtpAddress = 'mb2@contoso.com'; DisplayName = 'Mailbox 2' }
+                )
+            }
+            Mock Get-MailboxPermission {
+                param([string]$Identity)
+                if ($Identity -eq 'mb1') {
+                    [PSCustomObject]@{ User = 'user@contoso.com'; AccessRights = @('FullAccess') }
+                }
+            }
+            Mock Get-RecipientPermission {
+                param([string]$Identity)
+                if ($Identity -eq 'mb2') {
+                    [PSCustomObject]@{ Trustee = 'user@contoso.com'; AccessRights = @('SendAs') }
+                }
+            }
+        }
+
+        It 'Returns 2 objects' {
+            $result = Get-ExchangeMailboxPermission -UserPrincipalName 'user@contoso.com'
+            @($result).Count | Should -Be 2
+        }
+
+        It 'Result objects have Mailbox, DisplayName, FullAccess, SendAs properties' {
+            $result = Get-ExchangeMailboxPermission -UserPrincipalName 'user@contoso.com'
+            $obj    = $result | Select-Object -First 1
+            $obj.PSObject.Properties.Name | Should -Contain 'Mailbox'
+            $obj.PSObject.Properties.Name | Should -Contain 'DisplayName'
+            $obj.PSObject.Properties.Name | Should -Contain 'FullAccess'
+            $obj.PSObject.Properties.Name | Should -Contain 'SendAs'
+        }
+
+        It 'First result has FullAccess = $true for mb1' {
+            $result = Get-ExchangeMailboxPermission -UserPrincipalName 'user@contoso.com'
+            $mb1    = $result | Where-Object { $_.Mailbox -eq 'mb1@contoso.com' }
+            $mb1.FullAccess | Should -BeTrue
+        }
+
+        It 'Second result has SendAs = $true for mb2' {
+            $result = Get-ExchangeMailboxPermission -UserPrincipalName 'user@contoso.com'
+            $mb2    = $result | Where-Object { $_.Mailbox -eq 'mb2@contoso.com' }
+            $mb2.SendAs | Should -BeTrue
+        }
+    }
+
+    Context 'User has no permissions on any mailbox' {
+
+        BeforeAll {
+            Mock Get-Mailbox {
+                @(
+                    [PSCustomObject]@{ Alias = 'mb1'; PrimarySmtpAddress = 'mb1@contoso.com'; DisplayName = 'Mailbox 1' }
+                )
+            }
+            Mock Get-MailboxPermission  { }   # returns nothing
+            Mock Get-RecipientPermission { }  # returns nothing
+        }
+
+        It 'Returns empty (no objects) when user has no permissions' {
+            $result = Get-ExchangeMailboxPermission -UserPrincipalName 'noone@contoso.com'
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Error path — Get-Mailbox throws' {
+
+        BeforeAll {
+            Mock Get-Mailbox { throw 'Not connected to Exchange Online' }
+        }
+
+        It 'Returns $null when Get-Mailbox throws' {
+            $result = Get-ExchangeMailboxPermission -UserPrincipalName 'user@contoso.com'
+            $result | Should -BeNullOrEmpty
+        }
+    }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+Describe 'Set-ExchangeMailboxPermission' {
+
+    BeforeAll {
+        # Stub Exchange cmdlets so Pester can mock them on systems without the module.
+        if (-not (Get-Command Get-Mailbox              -ErrorAction SilentlyContinue)) {
+            function Get-Mailbox              { param([string]$RecipientTypeDetails, [string]$ErrorAction) }
+        }
+        if (-not (Get-Command Get-MailboxPermission    -ErrorAction SilentlyContinue)) {
+            function Get-MailboxPermission    { param([string]$Identity, [string]$ErrorAction) }
+        }
+        if (-not (Get-Command Get-RecipientPermission  -ErrorAction SilentlyContinue)) {
+            function Get-RecipientPermission  { param([string]$Identity, [string]$ErrorAction) }
+        }
+        if (-not (Get-Command Add-MailboxPermission    -ErrorAction SilentlyContinue)) {
+            function Add-MailboxPermission    { param([string]$Identity, [string]$User, [string[]]$AccessRights, [string]$InheritanceType, [switch]$AutoMapping, [string]$ErrorAction) }
+        }
+        if (-not (Get-Command Add-RecipientPermission  -ErrorAction SilentlyContinue)) {
+            function Add-RecipientPermission  { param([string]$Identity, [string]$Trustee, [string[]]$AccessRights, [switch]$Confirm, [string]$ErrorAction) }
+        }
+    }
+
+    Context 'Guard — Mirror missing SourceUser' {
+
+        It 'Returns "[!]" string when SourceUser is absent in Mirror mode' {
+            $result = Set-ExchangeMailboxPermission -Action 'Mirror' -TargetUser 'target@contoso.com'
+            $result | Should -Match '^\[!\]'
+        }
+
+        It 'Returns the Mirror-specific guard message when SourceUser is absent' {
+            $result = Set-ExchangeMailboxPermission -Action 'Mirror' -TargetUser 'target@contoso.com'
+            $result | Should -Be '[!] Mirror requires both SourceUser and TargetUser.'
+        }
+    }
+
+    Context 'Guard — Mirror missing TargetUser' {
+
+        It 'Returns "[!]" string when TargetUser is absent in Mirror mode' {
+            $result = Set-ExchangeMailboxPermission -Action 'Mirror' -SourceUser 'source@contoso.com'
+            $result | Should -Match '^\[!\]'
+        }
+
+        It 'Returns the Mirror-specific guard message when TargetUser is absent' {
+            $result = Set-ExchangeMailboxPermission -Action 'Mirror' -SourceUser 'source@contoso.com'
+            $result | Should -Be '[!] Mirror requires both SourceUser and TargetUser.'
+        }
+    }
+
+    Context 'Guard — Grant missing Mailbox' {
+
+        It 'Returns "[!]" string when Mailbox is absent in Grant mode' {
+            $result = Set-ExchangeMailboxPermission -Action 'Grant' -User 'user@contoso.com'
+            $result | Should -Match '^\[!\]'
+        }
+
+        It 'Returns the Grant-specific guard message when Mailbox is absent' {
+            $result = Set-ExchangeMailboxPermission -Action 'Grant' -User 'user@contoso.com'
+            $result | Should -Be '[!] Grant requires both Mailbox and User.'
+        }
+    }
+
+    Context 'Guard — Grant missing User' {
+
+        It 'Returns "[!]" string when User is absent in Grant mode' {
+            $result = Set-ExchangeMailboxPermission -Action 'Grant' -Mailbox 'shared@contoso.com'
+            $result | Should -Match '^\[!\]'
+        }
+
+        It 'Returns the Grant-specific guard message when User is absent' {
+            $result = Set-ExchangeMailboxPermission -Action 'Grant' -Mailbox 'shared@contoso.com'
+            $result | Should -Be '[!] Grant requires both Mailbox and User.'
+        }
+    }
+
+    Context 'Mirror happy path — source user has FullAccess on one mailbox' {
+
+        BeforeAll {
+            Mock Get-Mailbox {
+                @(
+                    [PSCustomObject]@{ Alias = 'mb1'; PrimarySmtpAddress = 'mb1@contoso.com'; DisplayName = 'Mailbox 1' }
+                )
+            }
+            Mock Get-MailboxPermission {
+                [PSCustomObject]@{ User = 'source@contoso.com'; AccessRights = @('FullAccess') }
+            }
+            Mock Get-RecipientPermission { }  # no SendAs
+            Mock Add-MailboxPermission   { }
+            Mock Add-RecipientPermission { }
+        }
+
+        It 'Returns "[OK]" string' {
+            $result = Set-ExchangeMailboxPermission -Action 'Mirror' `
+                        -SourceUser 'source@contoso.com' -TargetUser 'target@contoso.com'
+            $result | Should -Match '^\[OK\]'
+        }
+
+        It 'Return value includes the permission count and both users' {
+            $result = Set-ExchangeMailboxPermission -Action 'Mirror' `
+                        -SourceUser 'source@contoso.com' -TargetUser 'target@contoso.com'
+            $result | Should -Match 'source@contoso.com'
+            $result | Should -Match 'target@contoso.com'
+        }
+
+        It 'Calls Add-MailboxPermission for the FullAccess grant' {
+            Set-ExchangeMailboxPermission -Action 'Mirror' `
+                -SourceUser 'source@contoso.com' -TargetUser 'target@contoso.com' | Out-Null
+            Should -Invoke Add-MailboxPermission -Times 1 -Exactly
+        }
+    }
+
+    Context 'Mirror — no permissions on source user' {
+
+        BeforeAll {
+            Mock Get-Mailbox {
+                @(
+                    [PSCustomObject]@{ Alias = 'mb1'; PrimarySmtpAddress = 'mb1@contoso.com'; DisplayName = 'Mailbox 1' }
+                )
+            }
+            Mock Get-MailboxPermission   { }  # no FA
+            Mock Get-RecipientPermission { }  # no SA
+        }
+
+        It 'Returns "[!] No shared mailbox permissions found..." string' {
+            $result = Set-ExchangeMailboxPermission -Action 'Mirror' `
+                        -SourceUser 'nobody@contoso.com' -TargetUser 'target@contoso.com'
+            $result | Should -Match '^\[!\] No shared mailbox permissions found'
+        }
+    }
+
+    Context 'Grant happy path' {
+
+        BeforeAll {
+            Mock Add-MailboxPermission   { }
+            Mock Add-RecipientPermission { }
+        }
+
+        It 'Returns "[OK] Granted FullAccess and SendAs..." string' {
+            $result = Set-ExchangeMailboxPermission -Action 'Grant' `
+                        -Mailbox 'shared@contoso.com' -User 'user@contoso.com'
+            $result | Should -Match '^\[OK\] Granted FullAccess and SendAs'
+        }
+
+        It 'Return value includes the mailbox and user' {
+            $result = Set-ExchangeMailboxPermission -Action 'Grant' `
+                        -Mailbox 'shared@contoso.com' -User 'user@contoso.com'
+            $result | Should -Match 'shared@contoso.com'
+            $result | Should -Match 'user@contoso.com'
+        }
+
+        It 'Calls Add-MailboxPermission exactly once' {
+            Set-ExchangeMailboxPermission -Action 'Grant' `
+                -Mailbox 'shared@contoso.com' -User 'user@contoso.com' | Out-Null
+            Should -Invoke Add-MailboxPermission -Times 1 -Exactly
+        }
+
+        It 'Calls Add-RecipientPermission exactly once' {
+            Set-ExchangeMailboxPermission -Action 'Grant' `
+                -Mailbox 'shared@contoso.com' -User 'user@contoso.com' | Out-Null
+            Should -Invoke Add-RecipientPermission -Times 1 -Exactly
+        }
+    }
+
+    Context 'Error path — Add-MailboxPermission throws' {
+
+        BeforeAll {
+            Mock Add-MailboxPermission { throw 'Simulated Exchange failure' }
+        }
+
+        It 'Returns "[!]" string when Add-MailboxPermission throws' {
+            $result = Set-ExchangeMailboxPermission -Action 'Grant' `
+                        -Mailbox 'shared@contoso.com' -User 'user@contoso.com'
+            $result | Should -Match '^\[!\]'
+        }
+
+        It 'Does NOT surface exception text in the return value' {
+            $result = Set-ExchangeMailboxPermission -Action 'Grant' `
+                        -Mailbox 'shared@contoso.com' -User 'user@contoso.com'
+            $result | Should -Not -Match 'Simulated Exchange failure'
+        }
+    }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+Describe 'Get-IntuneManagementScript' {
+
+    BeforeAll {
+        # Ensure Invoke-MgGraphRequest stub exists so Pester can mock it on runners
+        # where Microsoft.Graph.Authentication is not installed.
+        if (-not (Get-Command Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+            function Invoke-MgGraphRequest { param([string]$Method, [string]$Uri, [string]$ErrorAction) }
+        }
+        if (-not (Get-Command Get-MgContext -ErrorAction SilentlyContinue)) {
+            function Get-MgContext { }
+        }
+    }
+
+    Context 'Guard — not connected to Graph' {
+
+        BeforeAll {
+            Mock Get-MgContext { return $null }
+        }
+
+        It 'Returns $null when not connected to Graph' {
+            $result = Get-IntuneManagementScript
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Does NOT call Invoke-MgGraphRequest when the guard fires' {
+            Mock Invoke-MgGraphRequest { }
+            Get-IntuneManagementScript | Out-Null
+            Should -Invoke Invoke-MgGraphRequest -Times 0
+        }
+    }
+
+    Context 'Happy path — two scripts returned' {
+
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 'abc' } }
+            Mock Invoke-MgGraphRequest {
+                @{
+                    value = @(
+                        @{ id = '1'; displayName = 'Script One'; fileName = 'one.ps1'
+                           runAsAccount = 'System'; enforcementType = 'required'
+                           createdDateTime = '2024-01-01'; lastModifiedDateTime = '2024-01-02'
+                           scriptContent = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes('# script one')) },
+                        @{ id = '2'; displayName = 'Script Two'; fileName = 'two.ps1'
+                           runAsAccount = 'User'; enforcementType = 'available'
+                           createdDateTime = '2024-02-01'; lastModifiedDateTime = '2024-02-02'
+                           scriptContent = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes('# script two')) }
+                    )
+                }
+            }
+            Mock Out-File { }
+            Mock New-Item { }
+            Mock Test-Path { $true }
+        }
+
+        It 'Returns 2 objects' {
+            $result = Get-IntuneManagementScript
+            @($result).Count | Should -Be 2
+        }
+
+        It 'Result objects have Id, DisplayName, FileName, RunAs, Enforcement, Created, Modified properties' {
+            $result = Get-IntuneManagementScript
+            $obj    = $result | Select-Object -First 1
+            foreach ($prop in @('Id','DisplayName','FileName','RunAs','Enforcement','Created','Modified')) {
+                $obj.PSObject.Properties.Name | Should -Contain $prop
+            }
+        }
+
+        It 'Id and DisplayName values are correctly mapped' {
+            $result = Get-IntuneManagementScript
+            ($result | Where-Object { $_.Id -eq '1' }).DisplayName | Should -Be 'Script One'
+            ($result | Where-Object { $_.Id -eq '2' }).DisplayName | Should -Be 'Script Two'
+        }
+
+        It 'Calls Invoke-MgGraphRequest exactly once (list call only)' {
+            Get-IntuneManagementScript | Out-Null
+            Should -Invoke Invoke-MgGraphRequest -Times 1 -Exactly
+        }
+    }
+
+    Context 'Search filter — returns only matching scripts' {
+
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 'abc' } }
+            Mock Invoke-MgGraphRequest {
+                @{
+                    value = @(
+                        @{ id = '1'; displayName = 'Deploy Chrome'; fileName = 'deploy-chrome.ps1'
+                           runAsAccount = 'System'; enforcementType = 'required'
+                           createdDateTime = '2024-01-01'; lastModifiedDateTime = '2024-01-02'; scriptContent = '' },
+                        @{ id = '2'; displayName = 'Cleanup Temp'; fileName = 'cleanup-temp.ps1'
+                           runAsAccount = 'System'; enforcementType = 'required'
+                           createdDateTime = '2024-01-01'; lastModifiedDateTime = '2024-01-02'; scriptContent = '' },
+                        @{ id = '3'; displayName = 'Deploy Firefox'; fileName = 'deploy-firefox.ps1'
+                           runAsAccount = 'System'; enforcementType = 'required'
+                           createdDateTime = '2024-01-01'; lastModifiedDateTime = '2024-01-02'; scriptContent = '' }
+                    )
+                }
+            }
+            Mock Out-File { }
+            Mock Test-Path { $true }
+        }
+
+        It 'Returns only scripts matching the Search filter' {
+            $result = Get-IntuneManagementScript -Search 'Deploy'
+            @($result).Count | Should -Be 2
+        }
+
+        It 'All returned scripts match the search term in DisplayName or FileName' {
+            $result = Get-IntuneManagementScript -Search 'Deploy'
+            $result | ForEach-Object {
+                ($_.DisplayName -like '*Deploy*' -or $_.FileName -like '*deploy*') | Should -BeTrue
+            }
+        }
+    }
+
+    Context 'Download path — detail endpoint called for each script' {
+        # Note: Out-File cannot be reliably mocked in Pester because the proxy's parameter
+        # validation rejects -Encoding UTF8 (string) before the mock body executes.
+        # We instead verify that Invoke-MgGraphRequest is called once per script for the
+        # detail endpoint (1 list call + N detail calls = N+1 total).
+
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 'abc' } }
+
+            # Any call returns the list plus valid detail payload.
+            Mock Invoke-MgGraphRequest {
+                @{
+                    value = @(
+                        @{ id = '1'; displayName = 'Script One'; fileName = 'one.ps1'
+                           runAsAccount = 'System'; enforcementType = 'required'
+                           createdDateTime = '2024-01-01'; lastModifiedDateTime = '2024-01-02'
+                           scriptContent = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes('# content')) },
+                        @{ id = '2'; displayName = 'Script Two'; fileName = 'two.ps1'
+                           runAsAccount = 'User'; enforcementType = 'available'
+                           createdDateTime = '2024-02-01'; lastModifiedDateTime = '2024-02-02'
+                           scriptContent = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes('# content')) }
+                    )
+                    fileName      = 'script.ps1'
+                    scriptContent = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes('# content'))
+                }
+            }
+            Mock New-Item { }
+            Mock Test-Path { $true }
+        }
+
+        It 'Calls Invoke-MgGraphRequest N+1 times when DownloadPath is provided (list + N detail calls)' {
+            # 2 scripts → 1 list + 2 detail calls = 3 total
+            Get-IntuneManagementScript -DownloadPath 'C:\Temp\Scripts' | Out-Null
+            Should -Invoke Invoke-MgGraphRequest -Times 3 -Exactly
+        }
+
+        It 'Calls Invoke-MgGraphRequest only once (list only) when no DownloadPath is specified' {
+            Get-IntuneManagementScript | Out-Null
+            Should -Invoke Invoke-MgGraphRequest -Times 1 -Exactly
+        }
+    }
+
+    Context 'Error path — Invoke-MgGraphRequest throws' {
+
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 'abc' } }
+            Mock Invoke-MgGraphRequest { throw 'Graph API error' }
+        }
+
+        It 'Returns $null when Invoke-MgGraphRequest throws' {
+            $result = Get-IntuneManagementScript
+            $result | Should -BeNullOrEmpty
         }
     }
 }

--- a/LazyWinAdminModule/Tests/Integrity.Tests.ps1
+++ b/LazyWinAdminModule/Tests/Integrity.Tests.ps1
@@ -83,6 +83,30 @@ Describe 'File Structure' {
         It 'Test-ComputerPort.ps1 exists' {
             Join-Path $script:ModuleRoot 'Private\Test-ComputerPort.ps1' | Should -Exist
         }
+
+        It 'Connect-ExchangeSession.ps1 exists' {
+            Join-Path $script:ModuleRoot 'Private\Connect-ExchangeSession.ps1' | Should -Exist
+        }
+
+        It 'Get-ExchangeMailboxPermission.ps1 exists' {
+            Join-Path $script:ModuleRoot 'Private\Get-ExchangeMailboxPermission.ps1' | Should -Exist
+        }
+
+        It 'Set-ExchangeMailboxPermission.ps1 exists' {
+            Join-Path $script:ModuleRoot 'Private\Set-ExchangeMailboxPermission.ps1' | Should -Exist
+        }
+
+        It 'Get-IntuneManagementScript.ps1 exists' {
+            Join-Path $script:ModuleRoot 'Private\Get-IntuneManagementScript.ps1' | Should -Exist
+        }
+
+        It 'Get-DeviceComplianceStatus.ps1 exists' {
+            Join-Path $script:ModuleRoot 'Private\Get-DeviceComplianceStatus.ps1' | Should -Exist
+        }
+
+        It 'Set-DeviceComplianceItem.ps1 exists' {
+            Join-Path $script:ModuleRoot 'Private\Set-DeviceComplianceItem.ps1' | Should -Exist
+        }
     }
 
     Context 'UI files' {
@@ -210,7 +234,33 @@ Describe 'XAML Validity' {
         @{ ControlName = 'lblCloudStatus'    }
         @{ ControlName = 'lblStatus'         }
         @{ ControlName = 'lblAdminStatus'    }
-        @{ ControlName = 'btnRestartAdmin'   }
+        @{ ControlName = 'btnRestartAdmin'           }
+        @{ ControlName = 'btnGetIntuneScripts'       }
+        @{ ControlName = 'txtIntuneScriptSearch'     }
+        @{ ControlName = 'txtIntuneScriptDownloadPath' }
+        @{ ControlName = 'btnDownloadIntuneScripts'  }
+        @{ ControlName = 'lvIntuneScripts'           }
+        @{ ControlName = 'btnCheckCompliance'        }
+        @{ ControlName = 'lvComplianceStatus'        }
+        @{ ControlName = 'btnFixLocation'            }
+        @{ ControlName = 'btnFixOutlookImages'       }
+        @{ ControlName = 'btnRemoveOneDrive'         }
+        @{ ControlName = 'txtUpdateHoursStart'       }
+        @{ ControlName = 'txtUpdateHoursEnd'         }
+        @{ ControlName = 'btnFixUpdateHours'         }
+        @{ ControlName = 'txtComplianceOutput'       }
+        @{ ControlName = 'txtExchangeUpn'            }
+        @{ ControlName = 'btnConnectExchange'        }
+        @{ ControlName = 'lblExchangeStatus'         }
+        @{ ControlName = 'btnGetMailboxPerms'        }
+        @{ ControlName = 'txtExchangeViewUser'       }
+        @{ ControlName = 'lvMailboxPerms'            }
+        @{ ControlName = 'txtExchangeSourceUser'     }
+        @{ ControlName = 'txtExchangeTargetUser'     }
+        @{ ControlName = 'btnMirrorMailboxPerms'     }
+        @{ ControlName = 'txtExchangeMailbox'        }
+        @{ ControlName = 'txtExchangeGrantUser'      }
+        @{ ControlName = 'btnGrantMailboxPerms'      }
     ) {
         param($ControlName)
         # XPath that finds any element whose local-name attribute (x:Name or Name) equals the control name
@@ -254,6 +304,16 @@ Describe 'ApplicationState Class' {
 
     It 'SyncHash.CloudConnected defaults to $false' {
         $script:State.SyncHash.CloudConnected | Should -BeFalse
+    }
+
+    It 'SyncHash.ExchangeConnected defaults to $false' {
+        $script:State.SyncHash.ExchangeConnected | Should -BeFalse
+    }
+
+    It 'SyncHash.UIQueue is a ConcurrentQueue' {
+        # An empty ConcurrentQueue evaluates as empty when piped — assert on the type directly.
+        ($null -ne $script:State.SyncHash.UIQueue) | Should -BeTrue
+        $script:State.SyncHash.UIQueue.GetType().Name | Should -BeLike 'ConcurrentQueue*'
     }
 
     It 'SyncHash.Logs is an ArrayList' {

--- a/LazyWinAdminModule/UI/MainView.xaml
+++ b/LazyWinAdminModule/UI/MainView.xaml
@@ -15,6 +15,7 @@
         </StackPanel>
 
         <TabControl Grid.Row="1" Background="Transparent" BorderThickness="0">
+
             <!-- TAB 1: CORE SYSTEM -->
             <TabItem Header="System &amp; Network">
                 <Grid Margin="10">
@@ -35,7 +36,7 @@
                         </Button>
                     </StackPanel>
                     <GroupBox Grid.Row="1" Header="System Output" Padding="5">
-                        <TextBox Name="txtOutput" IsReadOnly="True" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" 
+                        <TextBox Name="txtOutput" IsReadOnly="True" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"
                                  FontFamily="Consolas" Background="#FFFFFF" Padding="10"/>
                     </GroupBox>
                 </Grid>
@@ -57,11 +58,11 @@
                     <ListView Name="lvServices" Grid.Row="1" Background="White">
                         <ListView.View>
                             <GridView>
-                                <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Name}" Width="150"/>
+                                <GridViewColumn Header="Name"         DisplayMemberBinding="{Binding Name}"        Width="150"/>
                                 <GridViewColumn Header="Display Name" DisplayMemberBinding="{Binding DisplayName}" Width="250"/>
-                                <GridViewColumn Header="Status" DisplayMemberBinding="{Binding State}" Width="80"/>
-                                <GridViewColumn Header="Start Mode" DisplayMemberBinding="{Binding StartMode}" Width="100"/>
-                                <GridViewColumn Header="Account" DisplayMemberBinding="{Binding StartName}" Width="150"/>
+                                <GridViewColumn Header="Status"       DisplayMemberBinding="{Binding State}"       Width="80"/>
+                                <GridViewColumn Header="Start Mode"   DisplayMemberBinding="{Binding StartMode}"   Width="100"/>
+                                <GridViewColumn Header="Account"      DisplayMemberBinding="{Binding StartName}"   Width="150"/>
                             </GridView>
                         </ListView.View>
                     </ListView>
@@ -83,9 +84,9 @@
                     <ListView Name="lvSoftware" Grid.Row="1" Background="White">
                         <ListView.View>
                             <GridView>
-                                <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Name}" Width="350"/>
-                                <GridViewColumn Header="Version" DisplayMemberBinding="{Binding Version}" Width="150"/>
-                                <GridViewColumn Header="Vendor" DisplayMemberBinding="{Binding Vendor}" Width="250"/>
+                                <GridViewColumn Header="Name"         DisplayMemberBinding="{Binding Name}"        Width="350"/>
+                                <GridViewColumn Header="Version"      DisplayMemberBinding="{Binding Version}"     Width="150"/>
+                                <GridViewColumn Header="Vendor"       DisplayMemberBinding="{Binding Vendor}"      Width="250"/>
                                 <GridViewColumn Header="Install Date" DisplayMemberBinding="{Binding InstallDate}" Width="150"/>
                             </GridView>
                         </ListView.View>
@@ -106,7 +107,6 @@
                             <Button.ToolTip>Requires local Administrator rights — WMI classes Win32_PhysicalMemory and Win32_DiskDrive are restricted to admins</Button.ToolTip>
                         </Button>
                     </StackPanel>
-                    
                     <GroupBox Header="System Summary" Grid.Row="1" Margin="0,0,0,10" Padding="10">
                         <UniformGrid Columns="2">
                             <StackPanel Margin="5">
@@ -135,15 +135,14 @@
                             </StackPanel>
                         </UniformGrid>
                     </GroupBox>
-
                     <GroupBox Header="Disk Space" Grid.Row="2" Padding="5">
                         <ListView Name="lvHwDisks">
                             <ListView.View>
                                 <GridView>
-                                    <GridViewColumn Header="Drive" DisplayMemberBinding="{Binding DeviceID}" Width="60"/>
-                                    <GridViewColumn Header="Total (GB)" DisplayMemberBinding="{Binding SizeGB}" Width="100"/>
-                                    <GridViewColumn Header="Free (GB)" DisplayMemberBinding="{Binding FreeGB}" Width="100"/>
-                                    <GridViewColumn Header="Free (%)" DisplayMemberBinding="{Binding PercentFree}" Width="80"/>
+                                    <GridViewColumn Header="Drive"      DisplayMemberBinding="{Binding DeviceID}"    Width="60"/>
+                                    <GridViewColumn Header="Total (GB)" DisplayMemberBinding="{Binding SizeGB}"      Width="100"/>
+                                    <GridViewColumn Header="Free (GB)"  DisplayMemberBinding="{Binding FreeGB}"      Width="100"/>
+                                    <GridViewColumn Header="Free (%)"   DisplayMemberBinding="{Binding PercentFree}" Width="80"/>
                                 </GridView>
                             </ListView.View>
                         </ListView>
@@ -165,11 +164,11 @@
                     <ListView Name="lvNetwork" Grid.Row="1" Background="White">
                         <ListView.View>
                             <GridView>
-                                <GridViewColumn Header="Description" DisplayMemberBinding="{Binding Description}" Width="250"/>
-                                <GridViewColumn Header="IP Address" DisplayMemberBinding="{Binding IPAddress}" Width="200"/>
-                                <GridViewColumn Header="MAC Address" DisplayMemberBinding="{Binding MACAddress}" Width="130"/>
-                                <GridViewColumn Header="DHCP" DisplayMemberBinding="{Binding DHCPEnabled}" Width="60"/>
-                                <GridViewColumn Header="Gateway" DisplayMemberBinding="{Binding DefaultIPGateway}" Width="150"/>
+                                <GridViewColumn Header="Description" DisplayMemberBinding="{Binding Description}"      Width="250"/>
+                                <GridViewColumn Header="IP Address"  DisplayMemberBinding="{Binding IPAddress}"        Width="200"/>
+                                <GridViewColumn Header="MAC Address" DisplayMemberBinding="{Binding MACAddress}"       Width="130"/>
+                                <GridViewColumn Header="DHCP"        DisplayMemberBinding="{Binding DHCPEnabled}"      Width="60"/>
+                                <GridViewColumn Header="Gateway"     DisplayMemberBinding="{Binding DefaultIPGateway}" Width="150"/>
                             </GridView>
                         </ListView.View>
                     </ListView>
@@ -186,17 +185,17 @@
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                                <Button Name="btnGetLocalUsers" Content="List Local Users" Width="130" Padding="6" Background="#E8F0FE"/>
+                                <Button Name="btnGetLocalUsers"  Content="List Local Users"  Width="130" Padding="6" Background="#E8F0FE"/>
                                 <Button Name="btnGetLocalGroups" Content="List Local Groups" Width="130" Margin="10,0,0,0" Padding="6"/>
                             </StackPanel>
                             <ListView Name="lvLocalAccounts" Grid.Row="1" Background="White">
                                 <ListView.View>
                                     <GridView>
-                                        <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Name}" Width="150"/>
-                                        <GridViewColumn Header="Full Name / Caption" DisplayMemberBinding="{Binding FullName}" Width="250"/>
-                                        <GridViewColumn Header="Disabled" DisplayMemberBinding="{Binding Disabled}" Width="80"/>
-                                        <GridViewColumn Header="Status" DisplayMemberBinding="{Binding Status}" Width="100"/>
-                                        <GridViewColumn Header="SID" DisplayMemberBinding="{Binding SID}" Width="200"/>
+                                        <GridViewColumn Header="Name"              DisplayMemberBinding="{Binding Name}"     Width="150"/>
+                                        <GridViewColumn Header="Full Name/Caption" DisplayMemberBinding="{Binding FullName}" Width="250"/>
+                                        <GridViewColumn Header="Disabled"          DisplayMemberBinding="{Binding Disabled}" Width="80"/>
+                                        <GridViewColumn Header="Status"            DisplayMemberBinding="{Binding Status}"   Width="100"/>
+                                        <GridViewColumn Header="SID"               DisplayMemberBinding="{Binding SID}"      Width="200"/>
                                     </GridView>
                                 </ListView.View>
                             </ListView>
@@ -209,7 +208,7 @@
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                                <Button Name="btnGetEntraUsers" Content="Fetch Entra Users" Width="130" Padding="6" Background="#E8F0FE"/>
+                                <Button Name="btnGetEntraUsers"  Content="Fetch Entra Users"  Width="130" Padding="6" Background="#E8F0FE"/>
                                 <Button Name="btnGetEntraGroups" Content="Fetch Entra Groups" Width="130" Margin="10,0,0,0" Padding="6"/>
                                 <TextBlock Text="Search:" VerticalAlignment="Center" Margin="20,0,10,0"/>
                                 <TextBox Name="txtEntraSearch" Width="200" VerticalAlignment="Center" Padding="6"/>
@@ -217,17 +216,15 @@
                             <ListView Name="lvEntraIdentity" Grid.Row="1" Background="White">
                                 <ListView.View>
                                     <GridView>
-                                        <GridViewColumn Header="Display Name" DisplayMemberBinding="{Binding DisplayName}" Width="200"/>
+                                        <GridViewColumn Header="Display Name"     DisplayMemberBinding="{Binding DisplayName}"      Width="200"/>
                                         <GridViewColumn Header="UPN / Description" DisplayMemberBinding="{Binding UserPrincipalName}" Width="300"/>
-                                        <GridViewColumn Header="ID" DisplayMemberBinding="{Binding Id}" Width="250"/>
-                                        <GridViewColumn Header="Mail" DisplayMemberBinding="{Binding Mail}" Width="200"/>
+                                        <GridViewColumn Header="ID"               DisplayMemberBinding="{Binding Id}"               Width="250"/>
+                                        <GridViewColumn Header="Mail"             DisplayMemberBinding="{Binding Mail}"             Width="200"/>
                                     </GridView>
                                 </ListView.View>
                             </ListView>
                         </Grid>
                     </TabItem>
-
-                    <!-- Active Directory sub-tab — requires RSAT (rsat-ad-ds) on the running machine -->
                     <TabItem Header="Active Directory">
                         <Grid Margin="10">
                             <Grid.RowDefinitions>
@@ -244,11 +241,11 @@
                             <ListView Name="lvAdResults" Grid.Row="1" Background="White">
                                 <ListView.View>
                                     <GridView>
-                                        <GridViewColumn Header="Name"        DisplayMemberBinding="{Binding Name}"              Width="180"/>
-                                        <GridViewColumn Header="DN / UPN"    DisplayMemberBinding="{Binding DistinguishedName}" Width="350"/>
-                                        <GridViewColumn Header="Enabled"     DisplayMemberBinding="{Binding Enabled}"           Width="70"/>
-                                        <GridViewColumn Header="Last Logon"  DisplayMemberBinding="{Binding LastLogonDate}"     Width="150"/>
-                                        <GridViewColumn Header="OS / Dept"   DisplayMemberBinding="{Binding OperatingSystem}"   Width="200"/>
+                                        <GridViewColumn Header="Name"       DisplayMemberBinding="{Binding Name}"              Width="180"/>
+                                        <GridViewColumn Header="DN / UPN"   DisplayMemberBinding="{Binding DistinguishedName}" Width="350"/>
+                                        <GridViewColumn Header="Enabled"    DisplayMemberBinding="{Binding Enabled}"           Width="70"/>
+                                        <GridViewColumn Header="Last Logon" DisplayMemberBinding="{Binding LastLogonDate}"     Width="150"/>
+                                        <GridViewColumn Header="OS / Dept"  DisplayMemberBinding="{Binding OperatingSystem}"   Width="200"/>
                                     </GridView>
                                 </ListView.View>
                             </ListView>
@@ -257,7 +254,7 @@
                 </TabControl>
             </TabItem>
 
-            <!-- TAB 4: GOVERNANCE & COMPLIANCE -->
+            <!-- TAB 7: GOVERNANCE & COMPLIANCE -->
             <TabItem Header="Governance &amp; Compliance">
                 <TabControl Background="Transparent" BorderThickness="0" Margin="5">
                     <TabItem Header="Intune Devices">
@@ -274,12 +271,12 @@
                             <ListView Name="lvIntuneDevices" Grid.Row="1" Background="White">
                                 <ListView.View>
                                     <GridView>
-                                        <GridViewColumn Header="Device Name" DisplayMemberBinding="{Binding DeviceName}" Width="180"/>
-                                        <GridViewColumn Header="Primary User" DisplayMemberBinding="{Binding UserPrincipalName}" Width="220"/>
-                                        <GridViewColumn Header="Compliance" DisplayMemberBinding="{Binding ComplianceState}" Width="100"/>
-                                        <GridViewColumn Header="OS" DisplayMemberBinding="{Binding OS}" Width="100"/>
-                                        <GridViewColumn Header="Model" DisplayMemberBinding="{Binding Model}" Width="150"/>
-                                        <GridViewColumn Header="Serial" DisplayMemberBinding="{Binding SerialNumber}" Width="150"/>
+                                        <GridViewColumn Header="Device Name"   DisplayMemberBinding="{Binding DeviceName}"        Width="180"/>
+                                        <GridViewColumn Header="Primary User"  DisplayMemberBinding="{Binding UserPrincipalName}" Width="220"/>
+                                        <GridViewColumn Header="Compliance"    DisplayMemberBinding="{Binding ComplianceState}"   Width="100"/>
+                                        <GridViewColumn Header="OS"            DisplayMemberBinding="{Binding OS}"               Width="100"/>
+                                        <GridViewColumn Header="Model"         DisplayMemberBinding="{Binding Model}"            Width="150"/>
+                                        <GridViewColumn Header="Serial"        DisplayMemberBinding="{Binding SerialNumber}"      Width="150"/>
                                     </GridView>
                                 </ListView.View>
                             </ListView>
@@ -297,8 +294,40 @@
                             <ListView Name="lvAzureResources" Grid.Row="1" Background="White">
                                 <ListView.View>
                                     <GridView>
-                                        <GridViewColumn Header="Resource Type" DisplayMemberBinding="{Binding Name}" Width="400"/>
-                                        <GridViewColumn Header="Instance Count" DisplayMemberBinding="{Binding Count}" Width="150"/>
+                                        <GridViewColumn Header="Resource Type"   DisplayMemberBinding="{Binding Name}"  Width="400"/>
+                                        <GridViewColumn Header="Instance Count"  DisplayMemberBinding="{Binding Count}" Width="150"/>
+                                    </GridView>
+                                </ListView.View>
+                            </ListView>
+                        </Grid>
+                    </TabItem>
+                    <TabItem Header="Intune Scripts">
+                        <Grid Margin="10">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+                            <StackPanel Margin="0,0,0,10">
+                                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                    <Button Name="btnGetIntuneScripts" Content="List Scripts" Width="120" Padding="6" Background="#E8F0FE"/>
+                                    <TextBlock Text="Search:" VerticalAlignment="Center" Margin="20,0,10,0"/>
+                                    <TextBox Name="txtIntuneScriptSearch" Width="200" VerticalAlignment="Center" Padding="6"/>
+                                </StackPanel>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="Download folder:" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                                    <TextBox Name="txtIntuneScriptDownloadPath" Width="260" VerticalAlignment="Center" Padding="6" Text="C:\temp\IntuneScripts"/>
+                                    <Button Name="btnDownloadIntuneScripts" Content="Download All Listed" Width="150" Margin="10,0,0,0" Padding="6" Background="#E6F4EA">
+                                        <Button.ToolTip>Downloads script content from the listed results to the specified folder</Button.ToolTip>
+                                    </Button>
+                                </StackPanel>
+                            </StackPanel>
+                            <ListView Name="lvIntuneScripts" Grid.Row="1" Background="White">
+                                <ListView.View>
+                                    <GridView>
+                                        <GridViewColumn Header="Display Name"  DisplayMemberBinding="{Binding DisplayName}" Width="250"/>
+                                        <GridViewColumn Header="File Name"     DisplayMemberBinding="{Binding FileName}"    Width="200"/>
+                                        <GridViewColumn Header="Run As"        DisplayMemberBinding="{Binding RunAs}"       Width="100"/>
+                                        <GridViewColumn Header="Last Modified" DisplayMemberBinding="{Binding Modified}"   Width="180"/>
                                     </GridView>
                                 </ListView.View>
                             </ListView>
@@ -307,11 +336,147 @@
                 </TabControl>
             </TabItem>
 
-            <!-- TAB 5: REGISTRY -->
+            <!-- TAB 8: DEVICE COMPLIANCE (local) -->
+            <TabItem Header="Device Compliance">
+                <Grid Margin="10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                        <Button Name="btnCheckCompliance" Content="Check Compliance Status" Width="190" Padding="6" Background="#E8F0FE"/>
+                    </StackPanel>
+
+                    <ListView Name="lvComplianceStatus" Grid.Row="1" Background="White" Margin="0,0,0,10">
+                        <ListView.View>
+                            <GridView>
+                                <GridViewColumn Header="Item"        DisplayMemberBinding="{Binding Item}"        Width="200"/>
+                                <GridViewColumn Header="Status"      DisplayMemberBinding="{Binding Status}"      Width="140"/>
+                                <GridViewColumn Header="Description" DisplayMemberBinding="{Binding Description}" Width="500"/>
+                            </GridView>
+                        </ListView.View>
+                    </ListView>
+
+                    <GroupBox Header="Remediate" Grid.Row="2" Padding="10">
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                                <Button Name="btnFixLocation" Content="Enable Location Services" Width="190" Padding="6" Background="#E8F0FE">
+                                    <Button.ToolTip>Clears location policies and sets consent to Allow — requires Administrator</Button.ToolTip>
+                                </Button>
+                                <Button Name="btnFixOutlookImages" Content="Enable Outlook Images" Width="180" Margin="10,0,0,0" Padding="6" Background="#E8F0FE">
+                                    <Button.ToolTip>Sets BlockExtContent=0 in HKCU — no Administrator required</Button.ToolTip>
+                                </Button>
+                                <Button Name="btnRemoveOneDrive" Content="Remove OneDrive" Width="150" Margin="10,0,0,0" Padding="6" Background="#FAD2CF">
+                                    <Button.ToolTip>Uninstalls OneDrive and removes registry/file artifacts — requires Administrator</Button.ToolTip>
+                                </Button>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Windows Update Active Hours —" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                                <TextBlock Text="Start (0-23):" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                <TextBox Name="txtUpdateHoursStart" Width="45" Padding="4" Text="8" VerticalAlignment="Center"/>
+                                <TextBlock Text="End (0-23):" VerticalAlignment="Center" Margin="10,0,5,0"/>
+                                <TextBox Name="txtUpdateHoursEnd" Width="45" Padding="4" Text="18" VerticalAlignment="Center"/>
+                                <Button Name="btnFixUpdateHours" Content="Set Active Hours" Width="140" Margin="10,0,0,0" Padding="6" Background="#E8F0FE">
+                                    <Button.ToolTip>Sets Windows Update active hours in HKLM — requires Administrator</Button.ToolTip>
+                                </Button>
+                            </StackPanel>
+                            <TextBlock Name="txtComplianceOutput" Text="" Margin="0,10,0,0"
+                                       FontFamily="Consolas" FontSize="12" TextWrapping="Wrap" Foreground="#3C4043"/>
+                        </StackPanel>
+                    </GroupBox>
+                </Grid>
+            </TabItem>
+
+            <!-- TAB 9: EXCHANGE -->
+            <TabItem Header="Exchange">
+                <TabControl Background="Transparent" BorderThickness="0" Margin="5">
+                    <TabItem Header="Connection">
+                        <Grid Margin="10">
+                            <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Width="450">
+                                <TextBlock Text="Exchange Online" FontSize="20" FontWeight="Bold"
+                                           HorizontalAlignment="Center" Margin="0,0,0,20"/>
+                                <TextBlock Text="User Principal Name (optional — leave blank for interactive sign-in):"
+                                           TextWrapping="Wrap" Margin="0,0,0,5"/>
+                                <TextBox Name="txtExchangeUpn" Padding="6" Margin="0,0,0,15"/>
+                                <Button Name="btnConnectExchange" Content="Connect to Exchange Online"
+                                        Padding="12" FontSize="14" Background="#2F2F2F" Foreground="White"/>
+                                <TextBlock Name="lblExchangeStatus" Text="Not Connected"
+                                           HorizontalAlignment="Center" Margin="0,10,0,0" Foreground="#D93025"/>
+                            </StackPanel>
+                        </Grid>
+                    </TabItem>
+                    <TabItem Header="Mailbox Permissions">
+                        <Grid Margin="10">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <GroupBox Header="View User's Mailbox Access" Padding="8">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="User UPN:" VerticalAlignment="Center" Margin="0,0,10,0" Width="80"/>
+                                    <TextBox Name="txtExchangeViewUser" Width="280" Padding="5" VerticalAlignment="Center"/>
+                                    <Button Name="btnGetMailboxPerms" Content="List Access" Width="110"
+                                            Margin="10,0,0,0" Padding="6" Background="#E8F0FE"/>
+                                </StackPanel>
+                            </GroupBox>
+
+                            <ListView Name="lvMailboxPerms" Grid.Row="1" Margin="0,5,0,5" Background="White">
+                                <ListView.View>
+                                    <GridView>
+                                        <GridViewColumn Header="Mailbox"      DisplayMemberBinding="{Binding Mailbox}"      Width="270"/>
+                                        <GridViewColumn Header="Display Name" DisplayMemberBinding="{Binding DisplayName}"  Width="200"/>
+                                        <GridViewColumn Header="Full Access"  DisplayMemberBinding="{Binding FullAccess}"   Width="90"/>
+                                        <GridViewColumn Header="Send As"      DisplayMemberBinding="{Binding SendAs}"       Width="80"/>
+                                    </GridView>
+                                </ListView.View>
+                            </ListView>
+
+                            <GroupBox Header="Manage Permissions" Grid.Row="2" Padding="8">
+                                <UniformGrid Columns="2">
+                                    <StackPanel Margin="5">
+                                        <TextBlock Text="Mirror Permissions (e.g. offboarding / role handover)"
+                                                   FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                                            <TextBlock Text="Copy from:" VerticalAlignment="Center" Width="75"/>
+                                            <TextBox Name="txtExchangeSourceUser" Width="195" Padding="4"/>
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                            <TextBlock Text="Copy to:" VerticalAlignment="Center" Width="75"/>
+                                            <TextBox Name="txtExchangeTargetUser" Width="195" Padding="4"/>
+                                        </StackPanel>
+                                        <Button Name="btnMirrorMailboxPerms" Content="Mirror All Permissions"
+                                                Padding="6" Background="#E8F0FE"/>
+                                    </StackPanel>
+                                    <StackPanel Margin="5">
+                                        <TextBlock Text="Grant on Specific Mailbox"
+                                                   FontWeight="SemiBold" Margin="0,0,0,8"/>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                                            <TextBlock Text="Mailbox:" VerticalAlignment="Center" Width="75"/>
+                                            <TextBox Name="txtExchangeMailbox" Width="195" Padding="4"/>
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                            <TextBlock Text="Grant to:" VerticalAlignment="Center" Width="75"/>
+                                            <TextBox Name="txtExchangeGrantUser" Width="195" Padding="4"/>
+                                        </StackPanel>
+                                        <Button Name="btnGrantMailboxPerms" Content="Grant FullAccess + SendAs"
+                                                Padding="6" Background="#E6F4EA"/>
+                                    </StackPanel>
+                                </UniformGrid>
+                            </GroupBox>
+                        </Grid>
+                    </TabItem>
+                </TabControl>
+            </TabItem>
+
+            <!-- TAB 10: REGISTRY -->
             <TabItem Header="Registry">
                 <Grid Margin="10">
                     <StackPanel>
-                        <TextBlock Text="Quick Registry Read" FontSize="16" FontWeight="Bold" Margin="0,0,0,10"/>
+                        <TextBlock Text="Registry Editor" FontSize="16" FontWeight="Bold" Margin="0,0,0,10"/>
                         <UniformGrid Columns="2">
                             <StackPanel Margin="5">
                                 <TextBlock Text="Value Name:"/>
@@ -343,27 +508,30 @@
                         <TextBlock Text="Key Path:" Margin="5,10,0,0"/>
                         <TextBox Name="txtRegPath" Margin="5" Padding="6" Text="SOFTWARE\Microsoft\Windows\CurrentVersion"/>
                         <StackPanel Orientation="Horizontal" Margin="5,10,5,0">
-                            <Button Name="btnRegRead" Content="Read Value" Width="120" Padding="8" Background="#E8F0FE"/>
-                            <Button Name="btnRegWrite" Content="Write Value" Width="120" Margin="10,0,0,0" Padding="8" Background="#E6F4EA">
+                            <Button Name="btnRegRead"   Content="Read Value"       Width="120" Padding="8" Background="#E8F0FE"/>
+                            <Button Name="btnRegWrite"  Content="Write Value"      Width="120" Margin="10,0,0,0" Padding="8" Background="#E6F4EA">
                                 <Button.ToolTip>Writing to HKLM requires Administrator rights</Button.ToolTip>
                             </Button>
                             <Button Name="btnRegDelete" Content="Delete Value/Key" Width="120" Margin="10,0,0,0" Padding="8" Background="#FCE8E6">
                                 <Button.ToolTip>Deleting from HKLM requires Administrator rights</Button.ToolTip>
                             </Button>
                         </StackPanel>
-                        <TextBlock Name="txtRegResult" Text="Result will appear here..." Margin="5,20,5,0" FontStyle="Italic" Foreground="#5F6368" TextWrapping="Wrap"/>
+                        <TextBlock Name="txtRegResult" Text="Result will appear here..." Margin="5,20,5,0"
+                                   FontStyle="Italic" Foreground="#5F6368" TextWrapping="Wrap"/>
                     </StackPanel>
                 </Grid>
             </TabItem>
 
-            <!-- TAB 6: CLOUD AUTH -->
+            <!-- TAB 11: CLOUD AUTH -->
             <TabItem Header="Cloud Auth">
                 <Grid Margin="10">
                     <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Width="400">
-                        <TextBlock Text="Modern Authentication" FontSize="20" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,20"/>
-                        <Button Name="btnCloudLogin" Content="Sign in with Microsoft" Padding="15" FontSize="16" Background="#2F2F2F" Foreground="White"/>
-                        <TextBlock Name="lblCloudStatus" Text="Not Connected" HorizontalAlignment="Center" Margin="0,10,0,0" Foreground="#D93025"/>
-                        
+                        <TextBlock Text="Modern Authentication" FontSize="20" FontWeight="Bold"
+                                   HorizontalAlignment="Center" Margin="0,0,0,20"/>
+                        <Button Name="btnCloudLogin" Content="Sign in with Microsoft"
+                                Padding="15" FontSize="16" Background="#2F2F2F" Foreground="White"/>
+                        <TextBlock Name="lblCloudStatus" Text="Not Connected"
+                                   HorizontalAlignment="Center" Margin="0,10,0,0" Foreground="#D93025"/>
                         <Expander Header="Advanced (Service Principal)" Margin="0,30,0,0">
                             <StackPanel Margin="10">
                                 <TextBlock Text="Tenant ID:"/>
@@ -378,6 +546,7 @@
                     </StackPanel>
                 </Grid>
             </TabItem>
+
         </TabControl>
 
         <StatusBar Grid.Row="2" Background="#E8EAED" Padding="2">
@@ -389,7 +558,6 @@
                 <TextBlock Name="lblTime" Text=""/>
             </StatusBarItem>
             <Separator/>
-            <!-- Admin elevation indicator — updated at startup; hidden when already elevated -->
             <StatusBarItem>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Name="lblAdminStatus" Text="(!) Standard User" Foreground="#E37400"
@@ -401,7 +569,8 @@
                 </StackPanel>
             </StatusBarItem>
             <StatusBarItem HorizontalAlignment="Right">
-                <ProgressBar Name="pbBusy" Width="150" Height="18" IsIndeterminate="False" BorderThickness="0" Background="#DADCE0" Foreground="#1A73E8"/>
+                <ProgressBar Name="pbBusy" Width="150" Height="18" IsIndeterminate="False"
+                             BorderThickness="0" Background="#DADCE0" Foreground="#1A73E8"/>
             </StatusBarItem>
         </StatusBar>
     </Grid>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A complete modernisation of the classic LazyWinAdmin (2012) PowerShell GUI tool,
 | .NET | Included with PS 7.4+ |
 | Microsoft Graph modules | `Microsoft.Graph.Authentication`, `.Users`, `.Groups`, `.DeviceManagement` |
 | Azure modules | `Az.Accounts`, `Az.ResourceGraph` |
+| Exchange (optional) | `ExchangeOnlineManagement` — required for the Exchange tab |
 | RSAT (optional) | `Rsat.ActiveDirectory` — required for the Active Directory tab |
 
 ---
@@ -26,6 +27,9 @@ A complete modernisation of the classic LazyWinAdmin (2012) PowerShell GUI tool,
 Install-Module Microsoft.Graph.Authentication, Microsoft.Graph.Users, `
     Microsoft.Graph.Groups, Microsoft.Graph.DeviceManagement, `
     Az.Accounts, Az.ResourceGraph -Scope CurrentUser
+
+# Optional: Exchange tab
+Install-Module ExchangeOnlineManagement -Scope CurrentUser
 
 # Import and launch
 Import-Module .\LazyWinAdminModule\LazyWinAdminModule.psd1 -Force
@@ -76,8 +80,27 @@ Start-LazyWinAdmin
 - `SamAccountName` excluded from user results (PII protection)
 - Requires RSAT ActiveDirectory module
 
+### Device Compliance tab *(new in v1.2.0)*
+Reads and remediates local device compliance settings — no network required:
+
+| Check | Remediation |
+|---|---|
+| Location Services | Re-enables the `lfsvc` service and clears policy overrides |
+| OneDrive | Uninstalls OneDrive client cleanly (process + registry + files) |
+| Outlook External Images | Sets the registry flag that blocks automatic external image loading |
+| Windows Update active hours | Writes configurable start/end hours to HKLM (dynamic — enter any 0-23 value) |
+| UWF (Unified Write Filter) | Reports current UWF state (read-only — no remediation needed) |
+
+### Exchange tab *(new in v1.2.0)*
+Requires `ExchangeOnlineManagement` module and a one-time sign-in via the **Exchange › Connection** sub-tab.
+
+- **View Mailbox Permissions** — lists all shared mailboxes a user has FullAccess or SendAs on
+- **Mirror Permissions** — copies all mailbox permissions from a source user to a target user
+- **Grant Permissions** — grants FullAccess + SendAs on a specific mailbox to a user
+
 ### Governance & Compliance tab
 - **Intune** — list managed devices with compliance state, OS, model, serial
+- **Intune Scripts** *(new in v1.2.0)* — browse and optionally download all scripts deployed via Intune (`deviceManagement/deviceManagementScripts`). Uses `Invoke-MgGraphRequest` against the beta endpoint — no deprecated `Microsoft.Graph.Intune` needed.
 - **Azure Resources** — resource type summary via `Search-AzGraph` (not `Get-AzResource`)
 
 ### Registry tab
@@ -109,24 +132,30 @@ Click **Restart as Admin** in the status bar to relaunch elevated. Features that
 
 ```
 LazyWinAdminModule/
-├── LazyWinAdminModule.psd1     # Module manifest (v1.1.0, requires PS 7.4+)
+├── LazyWinAdminModule.psd1     # Module manifest (v1.2.0, requires PS 7.4+)
 ├── LazyWinAdminModule.psm1     # Root module — dot-sources all Private/Public files
 ├── Classes/
-│   └── ApplicationState.ps1   # LazyWinAdminState class: SyncHash, RunspacePool, CimSessions
-├── Private/                   # 16 private functions (CIM, Graph, Az, AD)
+│   └── ApplicationState.ps1   # LazyWinAdminState class: SyncHash, RunspacePool, CimSessions, UIQueue
+├── Private/                   # 22 private functions (CIM, Graph, Az, AD, Exchange, Compliance)
 ├── Public/
 │   └── Start-LazyWinAdmin.ps1 # WPF window, async dispatch, all button handlers
 ├── UI/
-│   └── MainView.xaml          # WPF layout
+│   └── MainView.xaml          # WPF layout (11 tabs)
 └── Tests/
     ├── Integrity.Tests.ps1    # File structure, manifest, XAML, ApplicationState
-    ├── Functions.Tests.ps1    # All 16 private functions (178 tests, 0 failures)
+    ├── Functions.Tests.ps1    # All private functions (212 tests, 0 failures)
     └── Run-Tests.ps1          # Test runner with summary output
 ```
 
 ### Async pattern
 
-All button actions run in background thread jobs via `Start-ThreadJob`. Results are marshalled back to the WPF UI thread using `Register-ObjectEvent` on the job's `StateChanged` event and `Dispatcher.Invoke`. The UI never blocks.
+All button actions run in background thread jobs via `Start-ThreadJob`. Completed results are enqueued into a `ConcurrentQueue` by a `Register-ObjectEvent` handler, then dequeued by a `DispatcherTimer` (50 ms tick) running on the WPF UI thread. This eliminates all cross-thread delegate issues and ensures the UI never blocks — even when multiple jobs complete simultaneously.
+
+> **v1.1.x note:** Earlier versions used `Dispatcher.InvokeAsync([action]{…})` which proved fragile under certain runspace/closure conditions. The ConcurrentQueue pattern replaces it entirely.
+
+### Local CIM routing *(fixed in v1.2.0)*
+
+In PowerShell 7+, `Get-CimInstance -ComputerName localhost` routes through WSMan (WinRM) even for the local machine. If WinRM is not running, CIM jobs stall for the full connection timeout (30 s), saturate the `Start-ThreadJob` pool (5 slots), and freeze the UI. All CIM-based private functions now detect a local target and omit `-ComputerName` entirely, using a direct in-process CIM session instead.
 
 ### Pre-flight guards
 
@@ -134,6 +163,7 @@ All button actions run in background thread jobs via `Start-ThreadJob`. Results 
 |---|---|
 | `$RequireComputerName` | Any CIM operation when the computer name field is empty |
 | `$RequireCloudSession` | Any Graph/Azure operation when not authenticated |
+| `$RequireExchangeSession` | Any Exchange operation when Exchange is not connected |
 
 ---
 
@@ -150,7 +180,7 @@ pwsh -NoProfile -File .\LazyWinAdminModule\Tests\Run-Tests.ps1 -Output Detailed
 pwsh -NoProfile -File .\LazyWinAdminModule\Tests\Run-Tests.ps1 -Suite Integrity
 ```
 
-**178 tests, 0 failures.** Requires Pester 5.0+ (auto-installed by the runner if missing).
+**212 tests, 0 failures.** Requires Pester 5.0+ (auto-installed by the runner if missing).
 
 ---
 
@@ -167,6 +197,15 @@ pwsh -NoProfile -File .\LazyWinAdminModule\Tests\Run-Tests.ps1 -Suite Integrity
 ---
 
 ## Version history
+
+### v1.2.0 — 2026
+- **Device Compliance tab** — check and remediate Location Services, OneDrive, Outlook external images, Windows Update active hours (dynamic), UWF state. Runs locally, no network required.
+- **Exchange tab** — view, mirror, and grant mailbox permissions via Exchange Online. Requires `ExchangeOnlineManagement` module. Auth tracked separately from Graph (`$state.SyncHash.ExchangeConnected`).
+- **Intune Scripts sub-tab** — browse and download all Intune-deployed scripts via `deviceManagement/deviceManagementScripts` beta endpoint.
+- **CIM local routing fix** — all 10 CIM-based private functions now detect localhost targets and skip `-ComputerName`, eliminating WinRM dependency and the associated UI freeze.
+- **Async architecture fix** — replaced `Dispatcher.InvokeAsync([action]{…})` with `ConcurrentQueue` + `DispatcherTimer` (50 ms tick). Event handlers only enqueue; UI thread only dequeues. No cross-thread delegate issues possible.
+- **`$RequireExchangeSession` guard** — Exchange operations blocked with a clear message when Exchange is not connected.
+- 212 Pester v5 tests, 0 failures (up from 178)
 
 ### v1.1.0 — 2026 (Modernized Edition)
 - Complete rewrite as a PowerShell 7.4+ WPF module


### PR DESCRIPTION
## Summary

- **Device Compliance tab** — check and remediate Location Services, OneDrive removal, Outlook external images, Windows Update active hours (dynamic 0-23 range), UWF state. Runs entirely locally, no network required.
- **Exchange tab** — view, mirror, and grant shared mailbox permissions via Exchange Online. Requires \`ExchangeOnlineManagement\` module (optional runtime check, not in \`RequiredModules\`). Tracked via \`\$state.SyncHash.ExchangeConnected\` with a \`\$RequireExchangeSession\` pre-flight guard.
- **Intune Scripts sub-tab** (Governance) — browse and download all Intune-deployed scripts via \`deviceManagement/deviceManagementScripts\` beta endpoint using \`Invoke-MgGraphRequest\`. No deprecated \`Microsoft.Graph.Intune\` needed.
- **CIM local routing fix** — all 10 CIM-based private functions detect localhost and skip \`-ComputerName\`, eliminating the WinRM dependency that caused services/hardware/software tabs to return no results and freeze the UI.
- **Async architecture fix** — replaced \`Dispatcher.InvokeAsync([action]{})\` with \`ConcurrentQueue[object]\` + \`DispatcherTimer\` (50 ms tick). Event handlers only enqueue; the UI thread only dequeues. Eliminates all cross-thread delegate issues and the tab-switching freeze.

## New files

| File | Purpose |
|---|---|
| \`Private/Connect-ExchangeSession.ps1\` | Interactive Exchange Online auth |
| \`Private/Get-ExchangeMailboxPermission.ps1\` | List shared mailbox access for a user |
| \`Private/Set-ExchangeMailboxPermission.ps1\` | Mirror or grant mailbox permissions |
| \`Private/Get-IntuneManagementScript.ps1\` | List/download Intune scripts via Graph beta |
| \`Private/Get-DeviceComplianceStatus.ps1\` | Read local compliance state (5 checks) |
| \`Private/Set-DeviceComplianceItem.ps1\` | Remediate compliance items locally |

## Test plan

- [x] All 212 Pester v5 tests pass (\`Run-Tests.ps1\` — up from 178)
- [x] 27 new XAML control assertions (Exchange tab, Compliance tab, Intune Scripts sub-tab)
- [x] 6 new private function existence checks
- [x] ApplicationState assertions for \`UIQueue\` and \`ExchangeConnected\`
- [ ] Manual: Services tab returns results without WinRM running
- [ ] Manual: Software Inventory tab does not freeze after switching from Services
- [ ] Manual: Device Compliance check shows correct status for all 5 items
- [ ] Manual: Exchange tab blocks with friendly message when not connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)