### PR TITLE
fix: replace Get-WmiObject with Get-CimInstance in UWF query (RULE-1)

### DIFF
--- a/LazyWinAdminModule/Private/Get-DeviceComplianceStatus.ps1
+++ b/LazyWinAdminModule/Private/Get-DeviceComplianceStatus.ps1
@@ -83,7 +83,7 @@ function Get-DeviceComplianceStatus {
         if ($osCaption -like '*Enterprise*') {
             $feature = Get-WindowsOptionalFeature -Online -FeatureName 'Client-UnifiedWriteFilter' -ErrorAction SilentlyContinue
             if ($feature.State -eq 'Enabled') {
-                $uwf    = Get-WmiObject -Namespace 'root\standardcimv2\embedded' -Class 'UWF_Filter' -ErrorAction SilentlyContinue
+                $uwf    = Get-CimInstance -Namespace 'root\standardcimv2\embedded' -ClassName 'UWF_Filter' -ErrorAction SilentlyContinue
                 $status = if ($uwf.CurrentEnabled) { 'Enabled' } else { 'Disabled' }
                 $detail = 'UWF feature installed; CurrentEnabled = ' + $uwf.CurrentEnabled
             }


### PR DESCRIPTION
## Summary

`Get-WmiObject` was removed from PowerShell 7. The cmdlet does not exist in the 7.4+ runtime this module targets, so the Unified Write Filter branch of `Get-DeviceComplianceStatus` would throw `CommandNotFoundException` the moment an Enterprise SKU reached that code path. Swaps the single offending line for `Get-CimInstance`.

## Changes

- `LazyWinAdminModule/Private/Get-DeviceComplianceStatus.ps1:86` — `Get-WmiObject -Namespace ... -Class ...` → `Get-CimInstance -Namespace ... -ClassName ...`.

Verified no other `Get-WmiObject` call sites exist in `LazyWinAdminModule/Private/`.

## Test plan

- [ ] `LazyWinAdminModule/Tests/Run-Tests.ps1` — full suite passes on `windows-latest`
- [ ] PSScriptAnalyzer clean on the modified file
- [ ] Manual smoke on Windows Enterprise: Device Compliance tab still reports UWF status correctly

## Risks / rollback

Low risk. `Get-CimInstance` against the `UWF_Filter` class is API-compatible for the one property read (`CurrentEnabled`). Rollback: `git revert`.

## .speq compliance

- CONTRACT CIM-ONLY — satisfied (no remaining `Get-WmiObject` in Private/).
- VOCABULARY — uses `CimSession` conventions (none needed here — no session, one-shot call).
- CALLS — CORE→nothing cross-layer; unchanged.

## AI review

@gemini-code-assist please review
@coderabbitai review
@kilo review

## Related

- `code-review-2026-04-24.md` — RULE-1 (CRITICAL)
- Tooling PR: #4