### PR TITLE
fix: prevent path traversal from Graph-supplied Intune script filenames (SEC-1)

### DIFF
--- a/LazyWinAdminModule/Private/Get-IntuneManagementScript.ps1
+++ b/LazyWinAdminModule/Private/Get-IntuneManagementScript.ps1
@@ -44,20 +44,39 @@ function Get-IntuneManagementScript {
                 New-Item -ItemType Directory -Path $DownloadPath -Force | Out-Null
             }
 
+            $resolvedRoot = (Resolve-Path -LiteralPath $DownloadPath).ProviderPath
+
             foreach ($script in $scripts) {
                 try {
                     $detail = Invoke-MgGraphRequest -Method GET `
                         -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts/$($script.id)" `
                         -ErrorAction Stop
                     if ($detail.scriptContent) {
-                        $decoded  = [System.Text.Encoding]::UTF8.GetString(
-                                        [System.Convert]::FromBase64String($detail.scriptContent))
-                        $filePath = Join-Path $DownloadPath $detail.fileName
-                        $decoded | Out-File -FilePath $filePath -Encoding UTF8 -Force
+                        $rawName  = [string]$detail.fileName
+                        $safeName = [System.IO.Path]::GetFileName($rawName)
+                        $invalid  = [System.IO.Path]::GetInvalidFileNameChars() -join ''
+                        $escaped  = [regex]::Escape($invalid)
+                        $safeName = [regex]::Replace($safeName, "[$escaped]", '_')
+                        if ([string]::IsNullOrWhiteSpace($safeName) -or $safeName -in '.', '..') {
+                            Write-Warning "Skipping script '$($script.displayName)': server-supplied filename is unsafe."
+                            continue
+                        }
+
+                        $filePath = Join-Path -Path $resolvedRoot -ChildPath $safeName
+                        $fullPath = [System.IO.Path]::GetFullPath($filePath)
+                        $rootWithSep = $resolvedRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+                        if (-not $fullPath.StartsWith($rootWithSep, [System.StringComparison]::OrdinalIgnoreCase)) {
+                            Write-Warning "Skipping script '$($script.displayName)': resolved path escapes download folder."
+                            continue
+                        }
+
+                        $decoded = [System.Text.Encoding]::UTF8.GetString(
+                                       [System.Convert]::FromBase64String($detail.scriptContent))
+                        $decoded | Out-File -LiteralPath $fullPath -Encoding UTF8 -Force
                     }
                 }
                 catch {
-                    Write-Warning "Could not download script '$($script.displayName)': $_"
+                    Write-Warning "Could not download script '$($script.displayName)'."
                 }
             }
         }


### PR DESCRIPTION
## Summary

Graph returned `deviceManagementScripts[].fileName` flowed straight through `Join-Path` into `Out-File`. A tenant admin (or anyone with rights to create an Intune script) could set `fileName` to `..\..\Windows\System32\...` or an absolute path and have the download overwrite files outside the user's chosen folder — a classic zip-slip primitive.

Also scrubbed the catch-block warning that expanded `$_` into the UI string.

## Changes

- `LazyWinAdminModule/Private/Get-IntuneManagementScript.ps1` (around line 47):
  1. `[Path]::GetFileName()` strips any directory components the server sent.
  2. Invalid filename chars rewritten to `_`.
  3. Empty / `.` / `..` basenames rejected.
  4. `Resolve-Path` pins root; joined target checked with `Path.GetFullPath` to still begin with the root separator (case-insensitive).
  5. `Out-File -LiteralPath` replaces `-FilePath` (no wildcard interpretation).
  6. Catch block no longer surfaces `$_` — exception detail could contain Graph request URL fragments.

## Test plan

- [ ] Full Pester suite passes (`Run-Tests.ps1`)
- [ ] Manual: with a tenant that has valid Intune scripts, download succeeds and files land in the chosen folder with original filenames
- [ ] Manual: synthesize a Graph response with `fileName = \"..\evil.ps1\"` — confirm the download is skipped with a warning and no file is written outside the target folder

## Risks / rollback

Low. The extra validation only rejects filenames that were never legitimate. Honest script names (`Install-App.ps1`, `Configure-Firewall.ps1`) pass through unchanged. Rollback: `git revert`.

## .speq compliance

- CLASSIFY `sensitive` / `pii` — unchanged. The catch-block `$_` scrub complies with "never surface exception detail".
- CONTRACTS — adds boundary validation at the file-system write boundary, matching the spirit of the ENTRA/INTUNE filter-validation contract.

## AI review

@gemini-code-assist please review
@coderabbitai review
@kilo review

## Related

- `code-review-2026-04-24.md` — SEC-1 (HIGH)
- Tooling PR: #4