### PR TITLE
fix: use -Filter ScriptBlock form in Get-ComputerADInfo (SEC-2)

### DIFF
--- a/LazyWinAdminModule/Private/Get-ComputerADInfo.ps1
+++ b/LazyWinAdminModule/Private/Get-ComputerADInfo.ps1
@@ -38,34 +38,54 @@ function Get-ComputerADInfo {
 
             switch ($Type) {
                 "Computer" {
-                    $ldapFilter = if ($AdFilter) { "Name -like '$AdFilter'" } `
-                                  elseif ($ComputerName) { "Name -eq '$ComputerName'" } `
-                                  else { "Name -like '*'" }
-
-                    return Get-ADComputer -Filter $ldapFilter `
-                        -Properties Description, OperatingSystem, OperatingSystemVersion,
-                                    LastLogonDate, DistinguishedName, Enabled -ErrorAction Stop |
+                    # ScriptBlock -Filter form: AD cmdlets parameterise $AdFilter / $ComputerName
+                    # safely into the LDAP query, eliminating interpolation-based injection.
+                    if ($AdFilter) {
+                        $result = Get-ADComputer -Filter { Name -like $AdFilter } `
+                            -Properties Description, OperatingSystem, OperatingSystemVersion,
+                                        LastLogonDate, DistinguishedName, Enabled -ErrorAction Stop
+                    }
+                    elseif ($ComputerName) {
+                        $result = Get-ADComputer -Filter { Name -eq $ComputerName } `
+                            -Properties Description, OperatingSystem, OperatingSystemVersion,
+                                        LastLogonDate, DistinguishedName, Enabled -ErrorAction Stop
+                    }
+                    else {
+                        $result = Get-ADComputer -Filter * `
+                            -Properties Description, OperatingSystem, OperatingSystemVersion,
+                                        LastLogonDate, DistinguishedName, Enabled -ErrorAction Stop
+                    }
+                    return $result |
                         Select-Object Name, DNSHostName, OperatingSystem, OperatingSystemVersion,
                                       LastLogonDate, Enabled, Description, DistinguishedName
                 }
                 "User" {
-                    $ldapFilter = if ($AdFilter) { "DisplayName -like '$AdFilter' -or SamAccountName -like '$AdFilter'" } `
-                                  else { "Enabled -eq `$true" }
-
                     # SamAccountName is pii — Select-Object excludes it from the returned object
                     # to prevent accidental logging in the UI layer
-                    return Get-ADUser -Filter $ldapFilter `
-                        -Properties DisplayName, EmailAddress, Department, Title,
-                                    LastLogonDate, Enabled -ErrorAction Stop |
+                    if ($AdFilter) {
+                        $result = Get-ADUser -Filter { DisplayName -like $AdFilter -or SamAccountName -like $AdFilter } `
+                            -Properties DisplayName, EmailAddress, Department, Title,
+                                        LastLogonDate, Enabled -ErrorAction Stop
+                    }
+                    else {
+                        $result = Get-ADUser -Filter { Enabled -eq $true } `
+                            -Properties DisplayName, EmailAddress, Department, Title,
+                                        LastLogonDate, Enabled -ErrorAction Stop
+                    }
+                    return $result |
                         Select-Object DisplayName, EmailAddress, Department, Title,
                                       LastLogonDate, Enabled, DistinguishedName
                 }
                 "Group" {
-                    $ldapFilter = if ($AdFilter) { "Name -like '$AdFilter'" } `
-                                  else { "Name -like '*'" }
-
-                    return Get-ADGroup -Filter $ldapFilter `
-                        -Properties Description, MemberOf -ErrorAction Stop |
+                    if ($AdFilter) {
+                        $result = Get-ADGroup -Filter { Name -like $AdFilter } `
+                            -Properties Description, MemberOf -ErrorAction Stop
+                    }
+                    else {
+                        $result = Get-ADGroup -Filter * `
+                            -Properties Description, MemberOf -ErrorAction Stop
+                    }
+                    return $result |
                         Select-Object Name, SamAccountName, GroupCategory, GroupScope, Description
                 }
             }


### PR DESCRIPTION
## Summary

Replace string-interpolated `-Filter` arguments with the ScriptBlock form for every `Get-AD*` call in `Get-ComputerADInfo`. The AD cmdlets parameterise the variable binding into the underlying LDAP query, so the input whitelist no longer carries correctness weight — it becomes defence-in-depth instead of the primary barrier.

## Changes

- `LazyWinAdminModule/Private/Get-ComputerADInfo.ps1` (all three `switch` arms):
  - Computer: `-Filter { Name -like \$AdFilter }` / `-Filter { Name -eq \$ComputerName }` / `-Filter *`
  - User: `-Filter { DisplayName -like \$AdFilter -or SamAccountName -like \$AdFilter }` / `-Filter { Enabled -eq \$true }`
  - Group: `-Filter { Name -like \$AdFilter }` / `-Filter *`

Existing input whitelist (line 34) left in place as a second layer. Broadening it to accept `\$`, `(`, `)` for legitimate AD names is tracked separately in the VALID-1 follow-up issue.

## Test plan

- [ ] Full Pester suite passes (`Run-Tests.ps1`)
- [ ] Manual against RSAT-equipped Windows host with a populated domain:
  - Computer search with wildcard (`*`) returns > 0 results
  - Computer search by exact hostname returns 1 result
  - User search by DisplayName fragment returns expected matches
  - Group search by wildcard returns > 0 results

## Risks / rollback

Low. ScriptBlock `-Filter` is the form the AD provider documentation recommends. Rollback: `git revert`.

## .speq compliance

- CLASSIFY `pii` (`ad_user.samaccountname`) — unchanged; this PR does not alter the already-scrubbed output projection. The Group branch still emits `SamAccountName`; that's SEC-5 in a separate PR.
- CONTRACTS `ad_user.samaccountname NEVER logged` — unchanged. The catch-block `Write-Warning \"...\$_\"` is tracked under SEC-3 / SEC-6.

## AI review

@gemini-code-assist please review
@coderabbitai review
@kilo review

## Related

- `code-review-2026-04-24.md` — SEC-2 (MEDIUM, security)
- Tooling PR: #4
- Follow-up issue: VALID-1 (broaden whitelist now that ScriptBlock removes the injection risk)