### PR TITLE
fix: honour $waitResult in Test-ComputerPort timeout path (BUG-1)

### DIFF
--- a/LazyWinAdminModule/Private/Test-ComputerPort.ps1
+++ b/LazyWinAdminModule/Private/Test-ComputerPort.ps1
@@ -12,17 +12,31 @@ function Test-ComputerPort {
     process {
         $tcpClient = $null
         try {
-            $tcpClient = New-Object System.Net.Sockets.TcpClient
+            $tcpClient   = New-Object System.Net.Sockets.TcpClient
             $connectTask = $tcpClient.BeginConnect($ComputerName, $Port, $null, $null)
-            
-            # Non-blocking wait with timeout to prevent hanging the runspace
+
+            # Wait for the async connect, but no longer than $TimeoutMs.
+            # WaitOne returns $true  = handle was signaled (connect completed, either OK or error)
+            #                $false = timed out, connect still pending in the background
+            # When it times out we must NOT call EndConnect — that would block the runspace
+            # waiting for the very operation the timeout was meant to abandon. The `finally`
+            # block disposes the TcpClient, which cancels the pending connect.
             $waitResult = $connectTask.AsyncWaitHandle.WaitOne($TimeoutMs, $false)
-            
-            if ($tcpClient.Connected) {
+
+            if (-not $waitResult) {
+                return "Closed/Filtered"
+            }
+
+            # Handle signaled. EndConnect either succeeds (socket is open) or throws a
+            # SocketException for connect-level failures (ECONNREFUSED, host unreachable,
+            # RST). Both are expected results of a reachability probe and map to
+            # "Closed/Filtered". Only unexpected framework/runtime errors fall through
+            # to the outer catch and surface as "Error".
+            try {
                 $tcpClient.EndConnect($connectTask)
                 return "Open"
             }
-            else {
+            catch [System.Net.Sockets.SocketException] {
                 return "Closed/Filtered"
             }
         }


### PR DESCRIPTION
## Summary

- `Test-ComputerPort` captured `\$waitResult` from `AsyncWaitHandle.WaitOne(\$TimeoutMs, \$false)` but never used it
- The decision between `Open` / `Closed/Filtered` was made on `\$tcpClient.Connected`, which races the async connect
- On timeout (the very condition the wait was introduced to handle) the code neither consulted the timeout flag nor called `EndConnect` on the pending handle — `Dispose` in `finally` mitigated the socket leak but the logic was still wrong on paper

## The bug, concretely

```powershell
# Before
$waitResult = $connectTask.AsyncWaitHandle.WaitOne($TimeoutMs, $false)  # captured...
if ($tcpClient.Connected) {                                              # ...and ignored
    $tcpClient.EndConnect($connectTask)
    return \"Open\"
}
else {
    return \"Closed/Filtered\"                                           # may be racey
}
```

Two failure modes:

1. **Unresponsive host race:** `WaitOne` signals true just as its scheduler quantum ends; `.Connected` hasn't flipped yet; we return `Closed/Filtered` on a port that was actually reachable.
2. **Timeout path:** `WaitOne` returns false, the background connect is still pending, `EndConnect` is never called. Dispose tears the socket down, but the codepath never acknowledges the timeout as a distinct state.

## The fix

```powershell
$waitResult = $connectTask.AsyncWaitHandle.WaitOne($TimeoutMs, $false)

if (-not $waitResult) {
    # Timed out. Do NOT call EndConnect — it would block the runspace
    # waiting on the very operation we just abandoned. `finally`
    # disposes the TcpClient, which cancels the pending connect.
    return \"Closed/Filtered\"
}

# Signaled. EndConnect either succeeds (Open) or throws SocketException
# (connect-level failure: ECONNREFUSED, unreachable, RST). Both map to
# \"Closed/Filtered\". Unexpected errors fall through as \"Error\".
try {
    $tcpClient.EndConnect($connectTask)
    return \"Open\"
}
catch [System.Net.Sockets.SocketException] {
    return \"Closed/Filtered\"
}
```

## Test plan

- [ ] `Test-ComputerPort -ComputerName localhost -Port 445` returns `Open` on a machine with SMB listening
- [ ] `Test-ComputerPort -ComputerName 10.255.255.1 -Port 22 -TimeoutMs 1500` returns `Closed/Filtered` inside ~1.5s (previously could hang waiting on .Connected to update, or return stale-false)
- [ ] `Test-ComputerPort -ComputerName localhost -Port 65535` returns `Closed/Filtered` (ECONNREFUSED path exercises the inner `catch [SocketException]`)
- [ ] The \"Ports\" GUI tab still renders green/red per host with no hang on unreachable hosts

## Risks / rollback

- **Risk:** A caller that was implicitly depending on `EndConnect` never being called on timeout (unlikely) would see behavioural change. No such caller exists in-tree.
- **Rollback:** `git revert` — single-function change.

Refs: `code-review-2026-04-24.md` BUG-1

---

@gemini-code-assist please review
@coderabbitai review
@kilo please review