### PR TITLE
refactor: use Parameter Sets in Set-ExchangeMailboxPermission

### DIFF
--- a/LazyWinAdminModule/Private/Set-ExchangeMailboxPermission.ps1
+++ b/LazyWinAdminModule/Private/Set-ExchangeMailboxPermission.ps1
@@ -3,54 +3,63 @@
     .SYNOPSIS
         Mirrors or grants mailbox permissions in Exchange Online.
     .DESCRIPTION
-        Two modes:
+        Two modes, selected by parameter set:
           Mirror — copies every FullAccess and SendAs permission held by SourceUser
                    across all shared mailboxes to TargetUser.  Used for offboarding /
-                   role handover scenarios.
+                   role handover scenarios.  Use the -SourceUser + -TargetUser pair.
           Grant  — grants FullAccess and SendAs on a single named mailbox to a user.
-    .PARAMETER Action
-        'Mirror' or 'Grant'.
-    .PARAMETER SourceUser
-        UPN of the user whose permissions are copied (Mirror only).
-    .PARAMETER TargetUser
-        UPN of the user who receives the copied permissions (Mirror only).
-    .PARAMETER Mailbox
-        Primary SMTP address or alias of the target shared mailbox (Grant only).
-    .PARAMETER User
-        UPN of the user to grant permissions to (Grant only).
-    #>
-    [CmdletBinding(SupportsShouldProcess = $true)]
-    param (
-        [Parameter(Mandatory=$true)]
-        [ValidateSet('Mirror', 'Grant')]
-        [string]$Action,
+                   Use the -Mailbox + -User pair.
 
-        # Mirror parameters
+        Parameter sets enforce the correct argument combination at bind time —
+        callers cannot mix Mirror and Grant parameters in one call.
+    .PARAMETER SourceUser
+        UPN of the user whose permissions are copied (Mirror set).
+    .PARAMETER TargetUser
+        UPN of the user who receives the copied permissions (Mirror set).
+    .PARAMETER Mailbox
+        Primary SMTP address or alias of the target shared mailbox (Grant set).
+    .PARAMETER User
+        UPN of the user to grant permissions to (Grant set).
+    .EXAMPLE
+        Set-ExchangeMailboxPermission -SourceUser old@contoso.com -TargetUser new@contoso.com
+        Mirrors all shared-mailbox permissions from old@ to new@.
+    .EXAMPLE
+        Set-ExchangeMailboxPermission -Mailbox shared@contoso.com -User user@contoso.com
+        Grants FullAccess and SendAs on shared@ to user@.
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Mirror', SupportsShouldProcess = $true)]
+    param (
+        # Mirror parameter set
+        [Parameter(Mandatory = $true, ParameterSetName = 'Mirror')]
+        [ValidateNotNullOrEmpty()]
         [string]$SourceUser,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Mirror')]
+        [ValidateNotNullOrEmpty()]
         [string]$TargetUser,
 
-        # Grant parameters
+        # Grant parameter set
+        [Parameter(Mandatory = $true, ParameterSetName = 'Grant')]
+        [ValidateNotNullOrEmpty()]
         [string]$Mailbox,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Grant')]
+        [ValidateNotNullOrEmpty()]
         [string]$User
     )
 
-    # Validate action-specific parameters BEFORE ShouldProcess so -WhatIf
-    # accurately reflects whether the action would actually run. Otherwise
-    # -WhatIf would claim it'd proceed on a doomed call.
-    if ($Action -eq 'Mirror' -and (-not $SourceUser -or -not $TargetUser)) {
-        return "[!] Mirror requires both SourceUser and TargetUser."
-    }
-    if ($Action -eq 'Grant' -and (-not $Mailbox -or -not $User)) {
-        return "[!] Grant requires both Mailbox and User."
-    }
+    # The parameter binder has already enforced the correct combination —
+    # missing or mixed params produce a ParameterBindingException before
+    # this body runs.  No manual validation needed.
+    $action = $PSCmdlet.ParameterSetName
+    $target = if ($action -eq 'Mirror') { "$SourceUser -> $TargetUser" } else { $Mailbox }
 
-    $target = if ($Action -eq 'Mirror') { "$SourceUser -> $TargetUser" } else { $Mailbox }
-    if (-not $PSCmdlet.ShouldProcess($target, "Set mailbox permission ($Action)")) {
+    if (-not $PSCmdlet.ShouldProcess($target, "Set mailbox permission ($action)")) {
         return "[!] Skipped by -WhatIf or -Confirm."
     }
 
     try {
-        if ($Action -eq 'Mirror') {
+        if ($action -eq 'Mirror') {
             $sharedMailboxes = Get-Mailbox -RecipientTypeDetails SharedMailbox -ErrorAction Stop
             $count = 0
 
@@ -79,7 +88,8 @@
                 return "[!] No shared mailbox permissions found for $SourceUser"
             }
         }
-        elseif ($Action -eq 'Grant') {
+        else {
+            # Grant parameter set
             Add-MailboxPermission -Identity $Mailbox -User $User `
                 -AccessRights FullAccess -InheritanceType All -AutoMapping:$false `
                 -ErrorAction Stop | Out-Null

--- a/LazyWinAdminModule/Public/Start-LazyWinAdmin.ps1
+++ b/LazyWinAdminModule/Public/Start-LazyWinAdmin.ps1
@@ -928,7 +928,7 @@
             Invoke-AsyncAction `
                 -InitializationScript ([scriptblock]::Create(". '$PrivatePath\Set-ExchangeMailboxPermission.ps1'")) `
                 -Parameters  @{ src = $src; tgt = $tgt } `
-                -ScriptBlock { Set-ExchangeMailboxPermission -Action Mirror -SourceUser $src -TargetUser $tgt } `
+                -ScriptBlock { Set-ExchangeMailboxPermission -SourceUser $src -TargetUser $tgt } `
                 -OnCompleted {
                     param($res)
                     $AppendOutput.Invoke("[Exchange Mirror] $res")
@@ -947,7 +947,7 @@
             Invoke-AsyncAction `
                 -InitializationScript ([scriptblock]::Create(". '$PrivatePath\Set-ExchangeMailboxPermission.ps1'")) `
                 -Parameters  @{ mb = $mb; u = $user } `
-                -ScriptBlock { Set-ExchangeMailboxPermission -Action Grant -Mailbox $mb -User $u } `
+                -ScriptBlock { Set-ExchangeMailboxPermission -Mailbox $mb -User $u } `
                 -OnCompleted {
                     param($res)
                     $AppendOutput.Invoke("[Exchange Grant] $res")

--- a/LazyWinAdminModule/Tests/Set-ExchangeMailboxPermission.Tests.ps1
+++ b/LazyWinAdminModule/Tests/Set-ExchangeMailboxPermission.Tests.ps1
@@ -40,52 +40,55 @@ BeforeAll {
 
 Describe 'Set-ExchangeMailboxPermission' {
 
-    Context 'Parameter validation' {
+    Context 'Parameter set enforcement' {
 
-        It 'Action parameter is mandatory — throws without it' {
+        # The parameter binder enforces required combinations. Missing or mixed
+        # parameters now throw ParameterBindingException before the function body
+        # runs — no manual validation needed inside the function.
+
+        It 'Throws when called with no parameters (no parameter set resolves)' {
             { Set-ExchangeMailboxPermission } | Should -Throw
         }
 
-        It 'Invalid Action value throws (ValidateSet enforcement)' {
-            { Set-ExchangeMailboxPermission -Action 'Delete' } | Should -Throw
+        It 'Mirror set: throws when only SourceUser is provided (TargetUser missing)' {
+            { Set-ExchangeMailboxPermission -SourceUser 'src@test.com' } | Should -Throw
+        }
+
+        It 'Mirror set: throws when only TargetUser is provided (SourceUser missing)' {
+            { Set-ExchangeMailboxPermission -TargetUser 'tgt@test.com' } | Should -Throw
+        }
+
+        It 'Grant set: throws when only Mailbox is provided (User missing)' {
+            { Set-ExchangeMailboxPermission -Mailbox 'mb@test.com' } | Should -Throw
+        }
+
+        It 'Grant set: throws when only User is provided (Mailbox missing)' {
+            { Set-ExchangeMailboxPermission -User 'user@test.com' } | Should -Throw
+        }
+
+        It 'Throws when mixing Mirror and Grant parameters' {
+            { Set-ExchangeMailboxPermission -SourceUser 'src' -Mailbox 'mb' } | Should -Throw
+        }
+
+        It 'Rejects empty-string SourceUser via ValidateNotNullOrEmpty' {
+            { Set-ExchangeMailboxPermission -SourceUser '' -TargetUser 'tgt' } | Should -Throw
+        }
+
+        It 'Rejects empty-string Mailbox via ValidateNotNullOrEmpty' {
+            { Set-ExchangeMailboxPermission -Mailbox '' -User 'u' } | Should -Throw
         }
     }
 
     Context 'WhatIf support' {
 
-        It 'Returns "[!] Skipped by -WhatIf or -Confirm." when -WhatIf is specified' {
-            $result = Set-ExchangeMailboxPermission -Action 'Grant' -Mailbox 'mb@test.com' -User 'u@test.com' -WhatIf
+        It 'Grant set: -WhatIf returns skip message' {
+            $result = Set-ExchangeMailboxPermission -Mailbox 'mb@test.com' -User 'u@test.com' -WhatIf
             $result | Should -Be '[!] Skipped by -WhatIf or -Confirm.'
         }
 
-        # Validation must run BEFORE ShouldProcess; otherwise -WhatIf would
-        # claim the action would proceed on a call that's actually a no-op.
-        It 'Returns Mirror validation error (not WhatIf-skip) when -WhatIf used with missing SourceUser/TargetUser' {
-            $result = Set-ExchangeMailboxPermission -Action 'Mirror' -WhatIf
-            $result | Should -Be '[!] Mirror requires both SourceUser and TargetUser.'
-        }
-
-        It 'Returns Grant validation error (not WhatIf-skip) when -WhatIf used with missing Mailbox/User' {
-            $result = Set-ExchangeMailboxPermission -Action 'Grant' -WhatIf
-            $result | Should -Be '[!] Grant requires both Mailbox and User.'
-        }
-    }
-
-    Context 'Mirror — missing SourceUser or TargetUser' {
-
-        It 'Returns [!] message when SourceUser is missing' {
-            $result = Set-ExchangeMailboxPermission -Action 'Mirror' -TargetUser 'target@test.com'
-            $result | Should -Be '[!] Mirror requires both SourceUser and TargetUser.'
-        }
-
-        It 'Returns [!] message when TargetUser is missing' {
-            $result = Set-ExchangeMailboxPermission -Action 'Mirror' -SourceUser 'source@test.com'
-            $result | Should -Be '[!] Mirror requires both SourceUser and TargetUser.'
-        }
-
-        It 'Returns [!] message when both SourceUser and TargetUser are missing' {
-            $result = Set-ExchangeMailboxPermission -Action 'Mirror'
-            $result | Should -Be '[!] Mirror requires both SourceUser and TargetUser.'
+        It 'Mirror set: -WhatIf returns skip message' {
+            $result = Set-ExchangeMailboxPermission -SourceUser 'src@test.com' -TargetUser 'tgt@test.com' -WhatIf
+            $result | Should -Be '[!] Skipped by -WhatIf or -Confirm.'
         }
     }
 
@@ -104,7 +107,7 @@ Describe 'Set-ExchangeMailboxPermission' {
         }
 
         It 'Returns [OK] message with count when permissions found' {
-            $result = Set-ExchangeMailboxPermission -Action 'Mirror' -SourceUser 'source@test.com' -TargetUser 'target@test.com'
+            $result = Set-ExchangeMailboxPermission -SourceUser 'source@test.com' -TargetUser 'target@test.com'
             $result | Should -Match '\[OK\]'
             $result | Should -BeLike '*Mirrored*permission*'
         }
@@ -119,22 +122,9 @@ Describe 'Set-ExchangeMailboxPermission' {
         }
 
         It 'Returns [!] no permissions found message' {
-            $result = Set-ExchangeMailboxPermission -Action 'Mirror' -SourceUser 'noone@test.com' -TargetUser 'target@test.com'
+            $result = Set-ExchangeMailboxPermission -SourceUser 'noone@test.com' -TargetUser 'target@test.com'
             $result | Should -Match '\[!\]'
             $result | Should -BeLike '*No shared mailbox permissions found*'
-        }
-    }
-
-    Context 'Grant — missing Mailbox or User' {
-
-        It 'Returns [!] message when Mailbox is missing' {
-            $result = Set-ExchangeMailboxPermission -Action 'Grant' -User 'user@test.com'
-            $result | Should -Be '[!] Grant requires both Mailbox and User.'
-        }
-
-        It 'Returns [!] message when User is missing' {
-            $result = Set-ExchangeMailboxPermission -Action 'Grant' -Mailbox 'mb@test.com'
-            $result | Should -Be '[!] Grant requires both Mailbox and User.'
         }
     }
 
@@ -146,7 +136,7 @@ Describe 'Set-ExchangeMailboxPermission' {
         }
 
         It 'Returns [OK] message confirming grant' {
-            $result = Set-ExchangeMailboxPermission -Action 'Grant' -Mailbox 'mailbox@test.com' -User 'user@test.com'
+            $result = Set-ExchangeMailboxPermission -Mailbox 'mailbox@test.com' -User 'user@test.com'
             $result | Should -Be '[OK] Granted FullAccess and SendAs on mailbox@test.com to user@test.com'
         }
     }
@@ -158,7 +148,7 @@ Describe 'Set-ExchangeMailboxPermission' {
         }
 
         It 'Returns [!] operation failed message when Get-Mailbox throws' {
-            $result = Set-ExchangeMailboxPermission -Action 'Mirror' -SourceUser 'src@test.com' -TargetUser 'tgt@test.com'
+            $result = Set-ExchangeMailboxPermission -SourceUser 'src@test.com' -TargetUser 'tgt@test.com'
             $result | Should -Match '\[!\]'
             $result | Should -BeLike '*Operation failed*'
         }


### PR DESCRIPTION
## Summary

Follow-up to PR #2 round-4 feedback from @gemini-code-assist. Replaces the manual `$Action` + manual-validation pattern with native PowerShell Parameter Sets, so the parameter binder enforces correct argument combinations before the function body runs.

> **Stacked on #2.** This branch was cut from `claude/nifty-goldwasser` since it builds on the round-3 fix (validation-before-ShouldProcess). After #2 merges, this rebases cleanly onto master.

## Changes

| File | Change |
|---|---|
| `LazyWinAdminModule/Private/Set-ExchangeMailboxPermission.ps1` | Signature + docs + body — drop `$Action` parameter and manual validation; use `$PSCmdlet.ParameterSetName` |
| `LazyWinAdminModule/Public/Start-LazyWinAdmin.ps1` | Drop `-Action` from the two GUI button-handler call sites |
| `LazyWinAdminModule/Tests/Set-ExchangeMailboxPermission.Tests.ps1` | Rewrite tests for new contract — missing-param tests now assert `Should -Throw` via parameter binder |

## Old vs New

```powershell
# OLD
Set-ExchangeMailboxPermission -Action Mirror -SourceUser x -TargetUser y
Set-ExchangeMailboxPermission -Action Grant  -Mailbox  x -User       y

# NEW (parameter sets infer the action)
Set-ExchangeMailboxPermission -SourceUser x -TargetUser y    # Mirror set
Set-ExchangeMailboxPermission -Mailbox    x -User       y    # Grant set
```

## Wins

- **Mixed-set calls rejected at bind time**: `Set-ExchangeMailboxPermission -SourceUser x -Mailbox y` now throws `ParameterBindingException` instead of silently no-op'ing on validation
- **Missing-mandatory-param calls throw at bind time**, before the function body runs — no need for a manual validation pass before `ShouldProcess`
- **`ValidateNotNullOrEmpty`** on each param — empty strings rejected at bind time
- **`DefaultParameterSetName='Mirror'`** — `Get-Help` shows Mirror first
- **No GUI behavior change**: the GUI already pre-validates form fields with `[string]::IsNullOrWhiteSpace` before calling, so empty-string paths can't reach the function

## Test plan

- [x] `verify-ci.ps1` (mirror of CI) — 5/5 steps clean locally
- [x] All 313 Pester tests pass (no count change — the tests changed shape, not coverage)
- [x] Zero PSScriptAnalyzer warnings or errors
- [x] Both GUI call sites updated; manual smoke test of Mirror + Grant flows would happen post-merge
- [ ] Reviewer pass

## Why this is its own PR

Originally declined as out-of-scope on PR #2 (which was a lint+test+CI hardening PR). Splitting the API-surface refactor into a separate PR keeps the diff focused and the review surface manageable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)