### PR TITLE
test: self-stub Graph/Az cmdlets so the suite runs on a clean dev box (#32)

### DIFF
--- a/LazyWinAdminModule/Tests/Functions.Tests.ps1
+++ b/LazyWinAdminModule/Tests/Functions.Tests.ps1
@@ -55,6 +55,43 @@ BeforeAll {
         ForEach-Object { . $_.FullName }
     Get-ChildItem (Join-Path $script:ModuleRoot 'Public')   -Filter '*.ps1' |
         ForEach-Object { . $_.FullName }
+
+    # ── Graph / Az cmdlet stubs ──────────────────────────────────────────────
+    # Pester v5 cannot Mock a command that doesn't exist. On a dev box without
+    # the Microsoft.Graph.* / Az.* modules installed, these cmdlets are absent
+    # and every Mock of them throws CommandNotFoundException (17 failures on a
+    # clean machine). Define no-op stubs — matching the parameters the private
+    # functions actually pass — ONLY when the real command is missing, so Mock
+    # has something to attach to. When the real modules are present (e.g. CI),
+    # each guard is false and the real cmdlets are used: identical behaviour to
+    # before. Mirrors the Exchange stub pattern in the Set-/Get-Exchange* tests.
+    if (-not (Get-Command Get-MgContext -ErrorAction SilentlyContinue)) {
+        function Get-MgContext { }
+    }
+    if (-not (Get-Command Connect-MgGraph -ErrorAction SilentlyContinue)) {
+        function Connect-MgGraph { param([string[]]$Scopes, [string]$TenantId, [string]$ClientId, $ClientSecretCredential) }
+    }
+    if (-not (Get-Command Get-MgUser -ErrorAction SilentlyContinue)) {
+        function Get-MgUser { param([string]$Filter, [int]$Top) }
+    }
+    if (-not (Get-Command Get-MgGroup -ErrorAction SilentlyContinue)) {
+        function Get-MgGroup { param([string]$Filter, [int]$Top) }
+    }
+    if (-not (Get-Command Get-MgDeviceManagementManagedDevice -ErrorAction SilentlyContinue)) {
+        function Get-MgDeviceManagementManagedDevice { param([string]$Filter, [int]$Top) }
+    }
+    if (-not (Get-Command Get-AzContext -ErrorAction SilentlyContinue)) {
+        function Get-AzContext { }
+    }
+    if (-not (Get-Command Search-AzGraph -ErrorAction SilentlyContinue)) {
+        function Search-AzGraph { param([string]$Query) }
+    }
+    # Get-AzResource is never called by the code under test — it is mocked only so
+    # tests can assert it is NOT invoked (Search-AzGraph is used instead). The
+    # negative assertion still needs the command to resolve on a clean box.
+    if (-not (Get-Command Get-AzResource -ErrorAction SilentlyContinue)) {
+        function Get-AzResource { param([string]$ResourceType, [string]$Name) }
+    }
 }
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/LazyWinAdminModule/Tests/Functions.Tests.ps1
+++ b/LazyWinAdminModule/Tests/Functions.Tests.ps1
@@ -69,7 +69,7 @@ BeforeAll {
         function Get-MgContext { }
     }
     if (-not (Get-Command Connect-MgGraph -ErrorAction SilentlyContinue)) {
-        function Connect-MgGraph { param([string[]]$Scopes, [string]$TenantId, [string]$ClientId, $ClientSecretCredential) }
+        function Connect-MgGraph { param([string[]]$Scopes, [string]$TenantId, [string]$ClientId, [pscredential]$ClientSecretCredential) }
     }
     if (-not (Get-Command Get-MgUser -ErrorAction SilentlyContinue)) {
         function Get-MgUser { param([string]$Filter, [int]$Top) }


### PR DESCRIPTION
## Summary
Pester v5 cannot `Mock` a command that does not exist. On a dev box **without** the `Microsoft.Graph.*` / `Az.*` modules installed, the Graph/Az tests in `Functions.Tests.ps1` throw `CommandNotFoundException` (~17 failures). The Exchange and AD tests already avoid this by defining `Get-Command`-guarded stubs; the Graph/Az tests did not.

## Changes
- Add guarded no-op stubs in the top `BeforeAll` of `Functions.Tests.ps1` for `Get-MgContext`, `Connect-MgGraph`, `Get-MgUser`, `Get-MgGroup`, `Get-MgDeviceManagementManagedDevice`, `Get-AzContext`, `Search-AzGraph`, and `Get-AzResource`.
- Stubs are defined **only** when the real command is absent, so CI (which installs the modules) is unaffected.

## Test plan
- [x] `Get-Entra*/Get-Intune*/Connect-ModernCloud/Get-AzureResourceSummary` Describe blocks: **28/28 pass, 0 failures** on a machine with no Graph/Az modules (previously 17 failures).
- [x] Diff is +37 lines, no line-ending churn.
- [ ] CI (windows-latest, modules installed) stays green — verified by the pipeline on this PR.

## Risks / rollback
Test-only change; no production code touched. If a stub signature ever mismatches a real call, the fix is to adjust the stub `param()` block. Rollback = revert this commit.

Closes #32

> Note: a separate, pre-existing issue causes the *full* `Run-Tests.ps1` to block on an interactive prompt on a non-interactive machine (unrelated to this change) — filed separately.