### PR TITLE
feat(entra): user-lifecycle ops - password, sessions, licenses, groups (#23, #24, #27)

### DIFF
--- a/LazyWinAdminModule/Private/Get-EntraGroupMember.ps1
+++ b/LazyWinAdminModule/Private/Get-EntraGroupMember.ps1
@@ -1,0 +1,40 @@
+function Get-EntraGroupMember {
+    <#
+    .SYNOPSIS
+        Lists the members of an Entra ID group.
+    .DESCRIPTION
+        Wraps Get-MgGroupMember. Requires an active Graph session. Property access is
+        guarded for Set-StrictMode safety.
+    .PARAMETER GroupId
+        The group's directory object id.
+    .OUTPUTS
+        PSCustomObject list (DisplayName, UserPrincipalName, Id) or $null.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$GroupId
+    )
+
+    if ($null -eq (Get-MgContext)) {
+        Write-Warning 'Not connected to Microsoft Graph.'
+        return $null
+    }
+
+    try {
+        return Get-MgGroupMember -GroupId $GroupId -All -ErrorAction Stop | ForEach-Object {
+            $apProp = $_.PSObject.Properties['AdditionalProperties']
+            $ap     = if ($apProp) { $apProp.Value } else { $null }
+            [PSCustomObject]@{
+                DisplayName       = if ($ap -and $ap.ContainsKey('displayName'))       { $ap['displayName'] }       else { $_.Id }
+                UserPrincipalName = if ($ap -and $ap.ContainsKey('userPrincipalName')) { $ap['userPrincipalName'] } else { $null }
+                Id                = $_.Id
+            }
+        }
+    }
+    catch {
+        Write-Warning "Error querying group members: $_"
+        return $null
+    }
+}

--- a/LazyWinAdminModule/Private/Get-EntraLicenseSku.ps1
+++ b/LazyWinAdminModule/Private/Get-EntraLicenseSku.ps1
@@ -1,0 +1,38 @@
+function Get-EntraLicenseSku {
+    <#
+    .SYNOPSIS
+        Lists the tenant's Microsoft 365 license SKUs with consumed / available counts.
+    .DESCRIPTION
+        Wraps Get-MgSubscribedSku and computes Available = Enabled - Consumed for each
+        SKU, so an operator can see at a glance which licenses are free to assign.
+        Requires an active Graph session.
+    .OUTPUTS
+        PSCustomObject list (SkuPartNumber, SkuId, Enabled, Consumed, Available) or $null.
+    #>
+    [CmdletBinding()]
+    param ()
+
+    if ($null -eq (Get-MgContext)) {
+        Write-Warning 'Not connected to Microsoft Graph.'
+        return $null
+    }
+
+    try {
+        return Get-MgSubscribedSku -ErrorAction Stop | ForEach-Object {
+            $prepaid  = $_.PSObject.Properties['PrepaidUnits']
+            $enabled  = if ($prepaid -and $prepaid.Value) { $prepaid.Value.Enabled } else { 0 }
+            $consumed = $_.ConsumedUnits
+            [PSCustomObject]@{
+                SkuPartNumber = $_.SkuPartNumber
+                SkuId         = $_.SkuId
+                Enabled       = $enabled
+                Consumed      = $consumed
+                Available     = $enabled - $consumed
+            }
+        }
+    }
+    catch {
+        Write-Warning "Error querying subscribed SKUs: $_"
+        return $null
+    }
+}

--- a/LazyWinAdminModule/Private/Get-EntraUserLicense.ps1
+++ b/LazyWinAdminModule/Private/Get-EntraUserLicense.ps1
@@ -1,0 +1,37 @@
+function Get-EntraUserLicense {
+    <#
+    .SYNOPSIS
+        Lists the Microsoft 365 licenses currently assigned to an Entra ID user.
+    .DESCRIPTION
+        Wraps Get-MgUserLicenseDetail. Requires an active Graph session.
+    .PARAMETER UserPrincipalName
+        The user to query.
+    .OUTPUTS
+        PSCustomObject list (SkuPartNumber, SkuId) or $null.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$UserPrincipalName
+    )
+
+    if ($null -eq (Get-MgContext)) {
+        Write-Warning 'Not connected to Microsoft Graph.'
+        return $null
+    }
+
+    try {
+        return Get-MgUserLicenseDetail -UserId $UserPrincipalName -ErrorAction Stop |
+            ForEach-Object {
+                [PSCustomObject]@{
+                    SkuPartNumber = $_.SkuPartNumber
+                    SkuId         = $_.SkuId
+                }
+            }
+    }
+    catch {
+        Write-Warning "Error querying user licenses: $_"
+        return $null
+    }
+}

--- a/LazyWinAdminModule/Private/Get-EntraUserMembership.ps1
+++ b/LazyWinAdminModule/Private/Get-EntraUserMembership.ps1
@@ -1,0 +1,43 @@
+function Get-EntraUserMembership {
+    <#
+    .SYNOPSIS
+        Lists the groups and directory roles an Entra ID user is a member of.
+    .DESCRIPTION
+        Wraps Get-MgUserMemberOf. Requires an active Graph session. Property access on
+        the returned directory objects is guarded so the function is safe under
+        Set-StrictMode.
+    .PARAMETER UserPrincipalName
+        The user (UPN or object id) to query.
+    .OUTPUTS
+        PSCustomObject list (DisplayName, Id, Type) or $null.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$UserPrincipalName
+    )
+
+    if ($null -eq (Get-MgContext)) {
+        Write-Warning 'Not connected to Microsoft Graph.'
+        return $null
+    }
+
+    try {
+        return Get-MgUserMemberOf -UserId $UserPrincipalName -All -ErrorAction Stop | ForEach-Object {
+            $apProp = $_.PSObject.Properties['AdditionalProperties']
+            $ap     = if ($apProp) { $apProp.Value } else { $null }
+            $name   = if ($ap -and $ap.ContainsKey('displayName')) { $ap['displayName'] } else { $_.Id }
+            $type   = if ($ap -and $ap.ContainsKey('@odata.type'))  { $ap['@odata.type'] -replace '#microsoft.graph.', '' } else { 'unknown' }
+            [PSCustomObject]@{
+                DisplayName = $name
+                Id          = $_.Id
+                Type        = $type
+            }
+        }
+    }
+    catch {
+        Write-Warning "Error querying user membership: $_"
+        return $null
+    }
+}

--- a/LazyWinAdminModule/Private/New-LwaSecurePassword.ps1
+++ b/LazyWinAdminModule/Private/New-LwaSecurePassword.ps1
@@ -1,0 +1,53 @@
+function New-LwaSecurePassword {
+    <#
+    .SYNOPSIS
+        Generates a cryptographically strong random password.
+    .DESCRIPTION
+        Uses the OS CSPRNG (RandomNumberGenerator) to build a password that always
+        contains at least one upper-case letter, one lower-case letter, one digit
+        and one symbol. Ambiguous characters (0/O, 1/l/I) are excluded so the
+        password can be read aloud or typed reliably. The value is returned as a
+        plain string for one-time display / clipboard use; callers MUST NOT log it
+        (it is a credential).
+    .PARAMETER Length
+        Total length. Minimum 8, default 16.
+    #>
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Pure function: generates and returns a value with no system state change.')]
+    [CmdletBinding()]
+    [OutputType([string])]
+    param (
+        [ValidateRange(8, 128)]
+        [int]$Length = 16
+    )
+
+    $upper  = 'ABCDEFGHJKLMNPQRSTUVWXYZ'
+    $lower  = 'abcdefghijkmnpqrstuvwxyz'
+    $digit  = '23456789'
+    $symbol = '!@#$%^&*-_=+?'
+    $all    = $upper + $lower + $digit + $symbol
+
+    $pick = {
+        param([string]$set)
+        $set[[System.Security.Cryptography.RandomNumberGenerator]::GetInt32($set.Length)]
+    }
+
+    # Guarantee one character from each required class, then fill from the full set.
+    $chars = [System.Collections.Generic.List[char]]::new()
+    $chars.Add((& $pick $upper))
+    $chars.Add((& $pick $lower))
+    $chars.Add((& $pick $digit))
+    $chars.Add((& $pick $symbol))
+    while ($chars.Count -lt $Length) {
+        $chars.Add((& $pick $all))
+    }
+
+    # Fisher-Yates shuffle so the guaranteed classes are not fixed at the front.
+    for ($i = $chars.Count - 1; $i -gt 0; $i--) {
+        $j = [System.Security.Cryptography.RandomNumberGenerator]::GetInt32($i + 1)
+        $tmp = $chars[$i]; $chars[$i] = $chars[$j]; $chars[$j] = $tmp
+    }
+
+    return (-join $chars)
+}

--- a/LazyWinAdminModule/Private/Revoke-EntraUserSession.ps1
+++ b/LazyWinAdminModule/Private/Revoke-EntraUserSession.ps1
@@ -1,0 +1,37 @@
+function Revoke-EntraUserSession {
+    <#
+    .SYNOPSIS
+        Revokes all active sign-in sessions (refresh tokens) for an Entra ID user.
+    .DESCRIPTION
+        Calls Revoke-MgUserSignInSession, invalidating the user's refresh tokens so
+        every session must re-authenticate. Used during offboarding or after a
+        suspected account compromise. Requires an active Graph session.
+    .PARAMETER UserPrincipalName
+        The user whose sessions are revoked.
+    .OUTPUTS
+        Status string.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$UserPrincipalName
+    )
+
+    if ($null -eq (Get-MgContext)) {
+        return '[!] Not connected to Microsoft Graph. Connect on the Cloud tab first.'
+    }
+    if (-not $PSCmdlet.ShouldProcess($UserPrincipalName, 'Revoke sign-in sessions')) {
+        return '[!] Skipped by -WhatIf or -Confirm.'
+    }
+
+    try {
+        Revoke-MgUserSignInSession -UserId $UserPrincipalName -ErrorAction Stop | Out-Null
+        return "[OK] Revoked all sign-in sessions for $UserPrincipalName"
+    }
+    catch {
+        Write-Verbose "Revoke session exception: $_"
+        return '[!] Failed to revoke sessions. Verify the UPN and your Graph permissions.'
+    }
+}

--- a/LazyWinAdminModule/Private/Set-EntraGroupMembership.ps1
+++ b/LazyWinAdminModule/Private/Set-EntraGroupMembership.ps1
@@ -1,0 +1,55 @@
+function Set-EntraGroupMembership {
+    <#
+    .SYNOPSIS
+        Adds or removes a user as a member of an Entra ID group.
+    .DESCRIPTION
+        Wraps New-MgGroupMember / Remove-MgGroupMemberByRef. Requires an active Graph
+        session with Group.ReadWrite.All. Adding an already-present member is treated
+        as success (idempotent).
+    .PARAMETER GroupId
+        The group's directory object id.
+    .PARAMETER UserId
+        The user's directory object id (resolve a UPN to its object id via the Entra
+        identity lookup first).
+    .PARAMETER Action
+        Add or Remove.
+    .OUTPUTS
+        Status string.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$GroupId,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$UserId,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Add', 'Remove')]
+        [string]$Action
+    )
+
+    if ($null -eq (Get-MgContext)) {
+        return '[!] Not connected to Microsoft Graph. Connect on the Cloud tab first.'
+    }
+    if (-not $PSCmdlet.ShouldProcess("$UserId in group $GroupId", "$Action group membership")) {
+        return '[!] Skipped by -WhatIf or -Confirm.'
+    }
+
+    try {
+        if ($Action -eq 'Add') {
+            New-MgGroupMember -GroupId $GroupId -DirectoryObjectId $UserId -ErrorAction Stop | Out-Null
+        }
+        else {
+            Remove-MgGroupMemberByRef -GroupId $GroupId -DirectoryObjectId $UserId -ErrorAction Stop | Out-Null
+        }
+        return "[OK] $Action membership for $UserId on group $GroupId"
+    }
+    catch {
+        Write-Verbose "Group membership exception: $_"
+        return '[!] Group membership update failed. Verify the group id and user object id.'
+    }
+}

--- a/LazyWinAdminModule/Private/Set-EntraUserLicense.ps1
+++ b/LazyWinAdminModule/Private/Set-EntraUserLicense.ps1
@@ -1,0 +1,56 @@
+function Set-EntraUserLicense {
+    <#
+    .SYNOPSIS
+        Assigns and/or removes a Microsoft 365 license SKU on an Entra ID user.
+    .DESCRIPTION
+        Wraps Set-MgUserLicense. Supply -AddSkuId, -RemoveSkuId, or both. Requires an
+        active Graph session with User.ReadWrite.All. Removing the SKU that hosts a
+        mailbox can orphan mailbox data, so confirm the mailbox is converted to shared
+        first (see the offboarding workflow).
+    .PARAMETER UserPrincipalName
+        The user to change.
+    .PARAMETER AddSkuId
+        SkuId (GUID) to assign.
+    .PARAMETER RemoveSkuId
+        SkuId (GUID) to remove.
+    .OUTPUTS
+        Status string.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$UserPrincipalName,
+
+        [string]$AddSkuId,
+
+        [string]$RemoveSkuId
+    )
+
+    if ($null -eq (Get-MgContext)) {
+        return '[!] Not connected to Microsoft Graph. Connect on the Cloud tab first.'
+    }
+    if (-not $AddSkuId -and -not $RemoveSkuId) {
+        return '[!] Specify a SKU to add and/or remove.'
+    }
+
+    $target = "$UserPrincipalName (add: '$AddSkuId' remove: '$RemoveSkuId')"
+    if (-not $PSCmdlet.ShouldProcess($target, 'Set user license')) {
+        return '[!] Skipped by -WhatIf or -Confirm.'
+    }
+
+    try {
+        $add    = @()
+        $remove = @()
+        if ($AddSkuId)    { $add    = @(@{ SkuId = $AddSkuId }) }
+        if ($RemoveSkuId) { $remove = @($RemoveSkuId) }
+
+        Set-MgUserLicense -UserId $UserPrincipalName -AddLicenses $add -RemoveLicenses $remove -ErrorAction Stop | Out-Null
+        return "[OK] Updated licenses for $UserPrincipalName"
+    }
+    catch {
+        Write-Verbose "License update exception: $_"
+        return '[!] License update failed. Verify the UPN and SKU IDs.'
+    }
+}

--- a/LazyWinAdminModule/Private/Set-EntraUserPassword.ps1
+++ b/LazyWinAdminModule/Private/Set-EntraUserPassword.ps1
@@ -1,0 +1,48 @@
+function Set-EntraUserPassword {
+    <#
+    .SYNOPSIS
+        Resets an Entra ID user's password via Microsoft Graph and returns the new password once.
+    .DESCRIPTION
+        Generates a strong password, applies it with Update-MgUser and (by default)
+        forces a change at next sign-in. Requires an active Graph session with the
+        User.ReadWrite.All scope. The generated password is returned in-memory on the
+        result object for ONE-TIME display / clipboard use only; it is never written
+        to logs, error messages, or exports (classified: credential).
+    .PARAMETER UserPrincipalName
+        The user whose password is reset.
+    .PARAMETER ForceChangeNextSignIn
+        Require the user to change the password at next sign-in. Default $true.
+    .OUTPUTS
+        PSCustomObject with Status (string) and Password (string, or $null on failure).
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [OutputType([PSCustomObject])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$UserPrincipalName,
+
+        [bool]$ForceChangeNextSignIn = $true
+    )
+
+    if ($null -eq (Get-MgContext)) {
+        return [PSCustomObject]@{ Status = '[!] Not connected to Microsoft Graph. Connect on the Cloud tab first.'; Password = $null }
+    }
+    if (-not $PSCmdlet.ShouldProcess($UserPrincipalName, 'Reset password')) {
+        return [PSCustomObject]@{ Status = '[!] Skipped by -WhatIf or -Confirm.'; Password = $null }
+    }
+
+    try {
+        $newPassword    = New-LwaSecurePassword -Length 16
+        $passwordProfile = @{
+            Password                      = $newPassword
+            ForceChangePasswordNextSignIn = $ForceChangeNextSignIn
+        }
+        Update-MgUser -UserId $UserPrincipalName -PasswordProfile $passwordProfile -ErrorAction Stop | Out-Null
+        return [PSCustomObject]@{ Status = "[OK] Password reset for $UserPrincipalName"; Password = $newPassword }
+    }
+    catch {
+        Write-Verbose "Password reset exception: $_"
+        return [PSCustomObject]@{ Status = '[!] Password reset failed. Verify the UPN and that you hold the required Graph scope.'; Password = $null }
+    }
+}

--- a/LazyWinAdminModule/Tests/EntraGroupMembership.Tests.ps1
+++ b/LazyWinAdminModule/Tests/EntraGroupMembership.Tests.ps1
@@ -1,0 +1,149 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Mock stub functions declare params to match real cmdlet signatures.')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseShouldProcessForStateChangingFunctions', '',
+    Justification = 'Stub functions emulate real Graph cmdlet names for mocking; they perform no work.')]
+param()
+
+BeforeAll {
+    $script:ModuleRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Classes') -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Private') -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Public')  -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+
+    if (-not (Get-Command Get-MgContext -ErrorAction SilentlyContinue)) {
+        function Get-MgContext { }
+    }
+    if (-not (Get-Command Get-MgUserMemberOf -ErrorAction SilentlyContinue)) {
+        function Get-MgUserMemberOf { param([string]$UserId, [switch]$All) }
+    }
+    if (-not (Get-Command Get-MgGroupMember -ErrorAction SilentlyContinue)) {
+        function Get-MgGroupMember { param([string]$GroupId, [switch]$All) }
+    }
+    if (-not (Get-Command New-MgGroupMember -ErrorAction SilentlyContinue)) {
+        function New-MgGroupMember { param([string]$GroupId, [string]$DirectoryObjectId) }
+    }
+    if (-not (Get-Command Remove-MgGroupMemberByRef -ErrorAction SilentlyContinue)) {
+        function Remove-MgGroupMemberByRef { param([string]$GroupId, [string]$DirectoryObjectId) }
+    }
+}
+
+Describe 'Get-EntraUserMembership' {
+
+    Context 'Guard - not connected' {
+        BeforeAll { Mock Get-MgContext { $null } }
+        It 'Returns $null when not connected' {
+            (Get-EntraUserMembership -UserPrincipalName 'u@t.com') | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Success' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock Get-MgUserMemberOf {
+                [PSCustomObject]@{
+                    Id                   = 'group-1'
+                    AdditionalProperties = @{ 'displayName' = 'Sales'; '@odata.type' = '#microsoft.graph.group' }
+                }
+            }
+        }
+        It 'Projects DisplayName and strips the odata type prefix' {
+            $m = Get-EntraUserMembership -UserPrincipalName 'u@t.com'
+            $m.DisplayName | Should -Be 'Sales'
+            $m.Type        | Should -Be 'group'
+            $m.Id          | Should -Be 'group-1'
+        }
+    }
+}
+
+Describe 'Get-EntraGroupMember' {
+
+    Context 'Guard - not connected' {
+        BeforeAll { Mock Get-MgContext { $null } }
+        It 'Returns $null when not connected' {
+            (Get-EntraGroupMember -GroupId 'group-1') | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Success' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock Get-MgGroupMember {
+                [PSCustomObject]@{
+                    Id                   = 'user-1'
+                    AdditionalProperties = @{ 'displayName' = 'Jane Doe'; 'userPrincipalName' = 'jane@t.com' }
+                }
+            }
+        }
+        It 'Projects member DisplayName and UPN' {
+            $m = Get-EntraGroupMember -GroupId 'group-1'
+            $m.DisplayName       | Should -Be 'Jane Doe'
+            $m.UserPrincipalName | Should -Be 'jane@t.com'
+        }
+    }
+}
+
+Describe 'Set-EntraGroupMembership' {
+
+    Context 'Guard - not connected' {
+        BeforeAll { Mock Get-MgContext { $null } }
+        It 'Returns [!] without calling New-MgGroupMember' {
+            Mock New-MgGroupMember { }
+            $r = Set-EntraGroupMembership -GroupId 'g' -UserId 'u' -Action 'Add'
+            $r | Should -Match '^\[!\]'
+            Should -Invoke New-MgGroupMember -Times 0
+        }
+    }
+
+    Context 'WhatIf' {
+        BeforeAll { Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } } }
+        It 'Skips under -WhatIf' {
+            Mock New-MgGroupMember { }
+            Set-EntraGroupMembership -GroupId 'g' -UserId 'u' -Action 'Add' -WhatIf | Should -BeLike '*Skipped by -WhatIf*'
+            Should -Invoke New-MgGroupMember -Times 0
+        }
+    }
+
+    Context 'Add' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock New-MgGroupMember { }
+        }
+        It 'Invokes New-MgGroupMember with the group and user ids' {
+            $r = Set-EntraGroupMembership -GroupId 'group-1' -UserId 'user-1' -Action 'Add'
+            $r | Should -Match '^\[OK\]'
+            Should -Invoke New-MgGroupMember -Times 1 -Exactly -ParameterFilter {
+                $GroupId -eq 'group-1' -and $DirectoryObjectId -eq 'user-1'
+            }
+        }
+    }
+
+    Context 'Remove' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock Remove-MgGroupMemberByRef { }
+        }
+        It 'Invokes Remove-MgGroupMemberByRef' {
+            $r = Set-EntraGroupMembership -GroupId 'group-1' -UserId 'user-1' -Action 'Remove'
+            $r | Should -Match '^\[OK\]'
+            Should -Invoke Remove-MgGroupMemberByRef -Times 1 -Exactly -ParameterFilter {
+                $GroupId -eq 'group-1' -and $DirectoryObjectId -eq 'user-1'
+            }
+        }
+    }
+
+    Context 'Failure' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock New-MgGroupMember { throw 'Insufficient privileges' }
+        }
+        It 'Returns sanitised [!]' {
+            $r = Set-EntraGroupMembership -GroupId 'g' -UserId 'u' -Action 'Add'
+            $r | Should -Match '^\[!\]'
+            $r | Should -Not -Match 'Insufficient privileges'
+        }
+    }
+}

--- a/LazyWinAdminModule/Tests/EntraUserLifecycle.Tests.ps1
+++ b/LazyWinAdminModule/Tests/EntraUserLifecycle.Tests.ps1
@@ -1,0 +1,286 @@
+﻿#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Mock stub functions declare params to match real cmdlet signatures.')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseShouldProcessForStateChangingFunctions', '',
+    Justification = 'Stub functions emulate real Graph cmdlet names for mocking; they perform no work.')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingUsernameAndPasswordParams', '',
+    Justification = 'Update-MgUser stub mirrors the real cmdlet signature for mocking; no credential is handled.')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingPlainTextForPassword', '',
+    Justification = 'Update-MgUser stub mirrors the real cmdlet signature for mocking; no password is stored or transmitted.')]
+param()
+
+BeforeAll {
+    $script:ModuleRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Classes') -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Private') -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Public')  -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+
+    # Graph cmdlet stubs — only defined when the real command is absent, so Mock can attach.
+    if (-not (Get-Command Get-MgContext -ErrorAction SilentlyContinue)) {
+        function Get-MgContext { }
+    }
+    if (-not (Get-Command Update-MgUser -ErrorAction SilentlyContinue)) {
+        function Update-MgUser { param([string]$UserId, $PasswordProfile, [bool]$AccountEnabled) }
+    }
+    if (-not (Get-Command Revoke-MgUserSignInSession -ErrorAction SilentlyContinue)) {
+        function Revoke-MgUserSignInSession { param([string]$UserId) }
+    }
+    if (-not (Get-Command Get-MgSubscribedSku -ErrorAction SilentlyContinue)) {
+        function Get-MgSubscribedSku { }
+    }
+    if (-not (Get-Command Get-MgUserLicenseDetail -ErrorAction SilentlyContinue)) {
+        function Get-MgUserLicenseDetail { param([string]$UserId) }
+    }
+    if (-not (Get-Command Set-MgUserLicense -ErrorAction SilentlyContinue)) {
+        function Set-MgUserLicense { param([string]$UserId, $AddLicenses, $RemoveLicenses) }
+    }
+}
+
+Describe 'New-LwaSecurePassword' {
+
+    It 'Returns a string of the requested length' {
+        (New-LwaSecurePassword -Length 20).Length | Should -Be 20
+    }
+
+    It 'Defaults to length 16' {
+        (New-LwaSecurePassword).Length | Should -Be 16
+    }
+
+    It 'Contains at least one upper, lower, digit and symbol' {
+        $pw = New-LwaSecurePassword
+        $pw | Should -Match '[A-Z]'
+        $pw | Should -Match '[a-z]'
+        $pw | Should -Match '[0-9]'
+        $pw | Should -Match '[!@#$%^&*\-_=+?]'
+    }
+
+    It 'Produces a different value on each call' {
+        (New-LwaSecurePassword) | Should -Not -Be (New-LwaSecurePassword)
+    }
+
+    It 'Rejects a length below the minimum' {
+        { New-LwaSecurePassword -Length 4 } | Should -Throw
+    }
+}
+
+Describe 'Set-EntraUserPassword' {
+
+    Context 'Guard - not connected to Graph' {
+        BeforeAll { Mock Get-MgContext { $null } }
+
+        It 'Returns [!] status and null password without calling Update-MgUser' {
+            Mock Update-MgUser { }
+            $result = Set-EntraUserPassword -UserPrincipalName 'u@t.com'
+            $result.Status   | Should -Match '^\[!\]'
+            $result.Password | Should -BeNullOrEmpty
+            Should -Invoke Update-MgUser -Times 0
+        }
+    }
+
+    Context 'WhatIf' {
+        BeforeAll { Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } } }
+
+        It 'Skips and returns null password under -WhatIf' {
+            Mock Update-MgUser { }
+            $result = Set-EntraUserPassword -UserPrincipalName 'u@t.com' -WhatIf
+            $result.Status   | Should -BeLike '*Skipped by -WhatIf*'
+            $result.Password | Should -BeNullOrEmpty
+            Should -Invoke Update-MgUser -Times 0
+        }
+    }
+
+    Context 'Success' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock Update-MgUser { }
+        }
+
+        It 'Returns [OK] status and a non-empty password' {
+            $result = Set-EntraUserPassword -UserPrincipalName 'u@t.com'
+            $result.Status   | Should -Match '^\[OK\]'
+            $result.Password | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Forces password change at next sign-in by default' {
+            Set-EntraUserPassword -UserPrincipalName 'u@t.com' | Out-Null
+            Should -Invoke Update-MgUser -Times 1 -Exactly -ParameterFilter {
+                $PasswordProfile.ForceChangePasswordNextSignIn -eq $true -and
+                -not [string]::IsNullOrEmpty($PasswordProfile.Password)
+            }
+        }
+
+        It 'Never places the password in the Status string (no leak into logs)' {
+            $result = Set-EntraUserPassword -UserPrincipalName 'u@t.com'
+            $result.Status | Should -Not -BeLike "*$($result.Password)*"
+        }
+    }
+
+    Context 'Failure' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock Update-MgUser { throw 'Insufficient privileges to complete the operation' }
+        }
+
+        It 'Returns sanitised [!] status without exception detail' {
+            $result = Set-EntraUserPassword -UserPrincipalName 'u@t.com'
+            $result.Status   | Should -Match '^\[!\]'
+            $result.Status   | Should -Not -Match 'Insufficient privileges'
+            $result.Password | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Revoke-EntraUserSession' {
+
+    Context 'Guard - not connected' {
+        BeforeAll { Mock Get-MgContext { $null } }
+        It 'Returns [!] without calling Revoke-MgUserSignInSession' {
+            Mock Revoke-MgUserSignInSession { }
+            $r = Revoke-EntraUserSession -UserPrincipalName 'u@t.com'
+            $r | Should -Match '^\[!\]'
+            Should -Invoke Revoke-MgUserSignInSession -Times 0
+        }
+    }
+
+    Context 'Success' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock Revoke-MgUserSignInSession { }
+        }
+        It 'Returns [OK] and invokes the revoke cmdlet' {
+            $r = Revoke-EntraUserSession -UserPrincipalName 'u@t.com'
+            $r | Should -Match '^\[OK\]'
+            Should -Invoke Revoke-MgUserSignInSession -Times 1 -Exactly -ParameterFilter { $UserId -eq 'u@t.com' }
+        }
+    }
+
+    Context 'Failure' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock Revoke-MgUserSignInSession { throw 'Graph error' }
+        }
+        It 'Returns sanitised [!]' {
+            $r = Revoke-EntraUserSession -UserPrincipalName 'u@t.com'
+            $r | Should -Match '^\[!\]'
+            $r | Should -Not -Match 'Graph error'
+        }
+    }
+}
+
+Describe 'Get-EntraLicenseSku' {
+
+    Context 'Guard - not connected' {
+        BeforeAll { Mock Get-MgContext { $null } }
+        It 'Returns $null when not connected' {
+            (Get-EntraLicenseSku) | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Success' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock Get-MgSubscribedSku {
+                [PSCustomObject]@{
+                    SkuPartNumber = 'ENTERPRISEPACK'
+                    SkuId         = '00000000-0000-0000-0000-000000000001'
+                    ConsumedUnits = 8
+                    PrepaidUnits  = [PSCustomObject]@{ Enabled = 10 }
+                }
+            }
+        }
+        It 'Computes Available = Enabled - Consumed' {
+            $sku = Get-EntraLicenseSku
+            $sku.SkuPartNumber | Should -Be 'ENTERPRISEPACK'
+            $sku.Available     | Should -Be 2
+        }
+    }
+
+    Context 'Failure' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock Get-MgSubscribedSku { throw 'Graph error' }
+        }
+        It 'Returns $null on error' {
+            (Get-EntraLicenseSku) | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Get-EntraUserLicense' {
+
+    Context 'Guard - not connected' {
+        BeforeAll { Mock Get-MgContext { $null } }
+        It 'Returns $null when not connected' {
+            (Get-EntraUserLicense -UserPrincipalName 'u@t.com') | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Success' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock Get-MgUserLicenseDetail {
+                [PSCustomObject]@{ SkuPartNumber = 'ENTERPRISEPACK'; SkuId = 'sku-1' }
+            }
+        }
+        It 'Returns the user license SKUs' {
+            $lic = Get-EntraUserLicense -UserPrincipalName 'u@t.com'
+            $lic.SkuPartNumber | Should -Be 'ENTERPRISEPACK'
+        }
+    }
+}
+
+Describe 'Set-EntraUserLicense' {
+
+    Context 'Guard - not connected' {
+        BeforeAll { Mock Get-MgContext { $null } }
+        It 'Returns [!] without calling Set-MgUserLicense' {
+            Mock Set-MgUserLicense { }
+            $r = Set-EntraUserLicense -UserPrincipalName 'u@t.com' -AddSkuId 'sku-1'
+            $r | Should -Match '^\[!\]'
+            Should -Invoke Set-MgUserLicense -Times 0
+        }
+    }
+
+    Context 'No SKU specified' {
+        BeforeAll { Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } } }
+        It 'Returns [!] when neither add nor remove is given' {
+            Set-EntraUserLicense -UserPrincipalName 'u@t.com' | Should -BeLike '*Specify a SKU*'
+        }
+    }
+
+    Context 'WhatIf' {
+        BeforeAll { Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } } }
+        It 'Skips under -WhatIf' {
+            Mock Set-MgUserLicense { }
+            Set-EntraUserLicense -UserPrincipalName 'u@t.com' -AddSkuId 'sku-1' -WhatIf | Should -BeLike '*Skipped by -WhatIf*'
+            Should -Invoke Set-MgUserLicense -Times 0
+        }
+    }
+
+    Context 'Add and remove' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock Set-MgUserLicense { }
+        }
+        It 'Assigns the add SKU and leaves removes empty when only adding' {
+            Set-EntraUserLicense -UserPrincipalName 'u@t.com' -AddSkuId 'sku-add' | Out-Null
+            Should -Invoke Set-MgUserLicense -Times 1 -Exactly -ParameterFilter {
+                $AddLicenses[0].SkuId -eq 'sku-add' -and @($RemoveLicenses).Count -eq 0
+            }
+        }
+        It 'Passes the remove SKU id when only removing' {
+            Set-EntraUserLicense -UserPrincipalName 'u@t.com' -RemoveSkuId 'sku-rem' | Out-Null
+            Should -Invoke Set-MgUserLicense -Times 1 -Exactly -ParameterFilter {
+                $RemoveLicenses[0] -eq 'sku-rem' -and @($AddLicenses).Count -eq 0
+            }
+        }
+        It 'Returns [OK] on success' {
+            Set-EntraUserLicense -UserPrincipalName 'u@t.com' -AddSkuId 'sku-add' | Should -Match '^\[OK\]'
+        }
+    }
+}


### PR DESCRIPTION
Adds the day-to-day **Entra/M365 user-lifecycle** building blocks — all **without any app registration** (interactive Graph, delegated scopes). Stacked on #38 (shares no files with it); retarget to `master` after #38 merges.

## New private functions (each < 60 lines, single responsibility)
| Function | Purpose | Graph cmdlet |
|---|---|---|
| `New-LwaSecurePassword` | CSPRNG password, guaranteed complexity, no ambiguous chars | — (pure) |
| `Set-EntraUserPassword` | Reset password + force change next sign-in | `Update-MgUser` |
| `Revoke-EntraUserSession` | Invalidate all refresh tokens | `Revoke-MgUserSignInSession` |
| `Get-EntraLicenseSku` | Tenant SKUs with `Available = Enabled - Consumed` | `Get-MgSubscribedSku` |
| `Get-EntraUserLicense` | A user''s assigned SKUs | `Get-MgUserLicenseDetail` |
| `Set-EntraUserLicense` | Assign and/or remove a SKU | `Set-MgUserLicense` |
| `Get-EntraUserMembership` | Groups/roles a user belongs to | `Get-MgUserMemberOf` |
| `Get-EntraGroupMember` | A group''s members | `Get-MgGroupMember` |
| `Set-EntraGroupMembership` | Add/remove a user | `New-MgGroupMember` / `Remove-MgGroupMemberByRef` |

Together these are the atomic operations that the onboarding (#26) and offboarding (#25) orchestrators will compose.

## Security
- Every function guards on `Get-MgContext` and refuses when not connected.
- State-changers use `SupportsShouldProcess` (WhatIf-safe).
- The generated password is returned **in-memory on the result object only** — never written to logs, the status string, errors, or exports. A test asserts it never appears in the status string.

## Test plan
- [x] **34 mock-based unit tests** (25 lifecycle + 9 group) — guards, WhatIf, success, sanitised failure, count math, and the no-secret-leak assertion. All pass.
- [x] Combined Integrity + Exchange + Entra suites: **177/177, 0 failures**.
- [x] PSScriptAnalyzer clean (Error+Warning, repo settings) on all functions and test files.
- [ ] Live Graph writes not covered by mocks — require a real tenant + delegated scopes.

## Not in this PR (intentional)
- **UI wiring** — deferred to the `Start-LazyWinAdmin.ps1` modular split (#14) to avoid growing the 1015-line handler file.
- **Orchestrators** (#25 offboarding, #26 onboarding), **mailbox settings** (#28), **MFA report** (#29), **audit log** (#30) remain.

Closes #23
Closes #24
Closes #27