### PR TITLE
feat: mailbox settings + employee offboarding workflow (#25, #28)

### DIFF
--- a/LazyWinAdminModule/Private/Convert-ExchangeMailbox.ps1
+++ b/LazyWinAdminModule/Private/Convert-ExchangeMailbox.ps1
@@ -1,0 +1,40 @@
+function Convert-ExchangeMailbox {
+    <#
+    .SYNOPSIS
+        Converts a mailbox between Regular, Shared, Room and Equipment types.
+    .DESCRIPTION
+        Wraps Set-Mailbox -Type. Converting a leaver's mailbox to Shared is the standard
+        way to retain their mail without a paid license. Relies on the caller having an
+        active Exchange session.
+    .PARAMETER Mailbox
+        Primary SMTP address or alias of the mailbox.
+    .PARAMETER Type
+        Target type: Shared, Regular, Room or Equipment.
+    .OUTPUTS
+        Status string.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Mailbox,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Shared', 'Regular', 'Room', 'Equipment')]
+        [string]$Type
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($Mailbox, "Convert mailbox to $Type")) {
+        return '[!] Skipped by -WhatIf or -Confirm.'
+    }
+
+    try {
+        Set-Mailbox -Identity $Mailbox -Type $Type -ErrorAction Stop | Out-Null
+        return "[OK] Converted $Mailbox to a $Type mailbox"
+    }
+    catch {
+        Write-Warning "Mailbox conversion failed: $_"
+        return '[!] Mailbox conversion failed. Verify the Exchange connection and mailbox.'
+    }
+}

--- a/LazyWinAdminModule/Private/Invoke-EntraUserOffboarding.ps1
+++ b/LazyWinAdminModule/Private/Invoke-EntraUserOffboarding.ps1
@@ -1,0 +1,109 @@
+function Invoke-EntraUserOffboarding {
+    <#
+    .SYNOPSIS
+        Runs the standard leaver checklist for a user. Every step is opt-in.
+    .DESCRIPTION
+        Composes the individually-tested atomic operations into one workflow. Steps run
+        in a safe order (block sign-in first, licenses last). A failure in one step is
+        recorded and does NOT abort the rest. Returns a list of per-step results so the
+        UI can show exactly what happened. Passing -WhatIf performs a dry run: it
+        propagates to every underlying step, which each report a skip without changing
+        anything. The reset-password step deliberately omits the new password from the
+        report (the account is being disabled; the value is not needed and is a secret).
+    .PARAMETER UserPrincipalName
+        The leaver.
+    .PARAMETER BlockSignIn
+        Disable the account so the user cannot sign in.
+    .PARAMETER RevokeSessions
+        Invalidate all refresh tokens.
+    .PARAMETER ResetPassword
+        Reset the password to a random value (locks out cached credentials).
+    .PARAMETER ConvertMailboxToShared
+        Convert the mailbox to Shared so mail is retained without a license.
+    .PARAMETER AutoReplyMessage
+        When supplied, enable an Out-of-Office auto-reply with this text.
+    .PARAMETER DelegateMailboxTo
+        UPN of a manager/successor to grant FullAccess/SendAs/SendOnBehalf on the mailbox.
+    .PARAMETER RemoveLicenseSkuId
+        One or more SKU ids to remove (do this AFTER converting to shared).
+    .PARAMETER RemoveFromGroups
+        Remove the user from every group they belong to.
+    .OUTPUTS
+        List of PSCustomObject (Step, Result).
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [OutputType([System.Collections.Generic.List[object]])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$UserPrincipalName,
+
+        [switch]$BlockSignIn,
+        [switch]$RevokeSessions,
+        [switch]$ResetPassword,
+        [switch]$ConvertMailboxToShared,
+        [string]$AutoReplyMessage,
+        [string]$DelegateMailboxTo,
+        [string[]]$RemoveLicenseSkuId,
+        [switch]$RemoveFromGroups
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($UserPrincipalName, 'Run offboarding workflow')) {
+        $dry = [System.Collections.Generic.List[object]]::new()
+        $dry.Add([PSCustomObject]@{ Step = 'Dry run'; Result = "[!] -WhatIf: would run the selected offboarding steps for $UserPrincipalName." })
+        return $dry
+    }
+
+    $report = [System.Collections.Generic.List[object]]::new()
+    $record = {
+        param([string]$step, [string]$result)
+        $report.Add([PSCustomObject]@{ Step = $step; Result = $result })
+    }
+
+    if ($BlockSignIn) {
+        & $record 'Block sign-in' (Set-EntraUserAccountState -UserPrincipalName $UserPrincipalName -Enabled:$false)
+    }
+    if ($RevokeSessions) {
+        & $record 'Revoke sessions' (Revoke-EntraUserSession -UserPrincipalName $UserPrincipalName)
+    }
+    if ($ResetPassword) {
+        $pwResult = Set-EntraUserPassword -UserPrincipalName $UserPrincipalName
+        & $record 'Reset password' $pwResult.Status
+    }
+    if ($ConvertMailboxToShared) {
+        & $record 'Convert mailbox to shared' (Convert-ExchangeMailbox -Mailbox $UserPrincipalName -Type Shared)
+    }
+    if ($PSBoundParameters.ContainsKey('AutoReplyMessage')) {
+        & $record 'Set auto-reply' (Set-ExchangeAutoReply -Mailbox $UserPrincipalName -State Enabled `
+            -InternalMessage $AutoReplyMessage -ExternalMessage $AutoReplyMessage)
+    }
+    if ($DelegateMailboxTo) {
+        & $record 'Delegate mailbox' (Set-ExchangeMailboxPermission -Mailbox $UserPrincipalName -User $DelegateMailboxTo)
+    }
+    if ($RemoveLicenseSkuId) {
+        foreach ($sku in $RemoveLicenseSkuId) {
+            & $record "Remove license $sku" (Set-EntraUserLicense -UserPrincipalName $UserPrincipalName -RemoveSkuId $sku)
+        }
+    }
+    if ($RemoveFromGroups) {
+        $objectId = try { (Get-MgUser -UserId $UserPrincipalName -ErrorAction Stop).Id } catch { $null }
+        if (-not $objectId) {
+            & $record 'Remove from groups' '[!] Could not resolve the user object id; group removal skipped.'
+        }
+        else {
+            $groups = @(Get-EntraUserMembership -UserPrincipalName $UserPrincipalName | Where-Object { $_ })
+            if ($groups.Count -eq 0) {
+                & $record 'Remove from groups' '[OK] No group memberships to remove.'
+            }
+            foreach ($g in $groups) {
+                & $record "Remove from group $($g.DisplayName)" (Set-EntraGroupMembership -GroupId $g.Id -UserId $objectId -Action Remove)
+            }
+        }
+    }
+
+    if ($report.Count -eq 0) {
+        & $record 'No action' '[!] No offboarding steps were selected.'
+    }
+
+    return $report
+}

--- a/LazyWinAdminModule/Private/Set-EntraUserAccountState.ps1
+++ b/LazyWinAdminModule/Private/Set-EntraUserAccountState.ps1
@@ -1,0 +1,44 @@
+function Set-EntraUserAccountState {
+    <#
+    .SYNOPSIS
+        Enables or blocks (disables) sign-in for an Entra ID user.
+    .DESCRIPTION
+        Wraps Update-MgUser -AccountEnabled. Blocking sign-in is the first step of
+        offboarding. Requires an active Graph session with User.ReadWrite.All.
+    .PARAMETER UserPrincipalName
+        The user to change.
+    .PARAMETER Enabled
+        $true enables sign-in; $false blocks it.
+    .OUTPUTS
+        Status string.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$UserPrincipalName,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$Enabled
+    )
+
+    if ($null -eq (Get-MgContext)) {
+        return '[!] Not connected to Microsoft Graph. Connect on the Cloud tab first.'
+    }
+
+    $verb = if ($Enabled) { 'Enable sign-in' } else { 'Block sign-in' }
+    if (-not $PSCmdlet.ShouldProcess($UserPrincipalName, $verb)) {
+        return '[!] Skipped by -WhatIf or -Confirm.'
+    }
+
+    try {
+        Update-MgUser -UserId $UserPrincipalName -AccountEnabled:$Enabled -ErrorAction Stop | Out-Null
+        $stateWord = if ($Enabled) { 'enabled' } else { 'blocked' }
+        return "[OK] Sign-in $stateWord for $UserPrincipalName"
+    }
+    catch {
+        Write-Verbose "Account state exception: $_"
+        return '[!] Account state update failed. Verify the UPN and your Graph permissions.'
+    }
+}

--- a/LazyWinAdminModule/Private/Set-ExchangeAutoReply.ps1
+++ b/LazyWinAdminModule/Private/Set-ExchangeAutoReply.ps1
@@ -1,0 +1,55 @@
+function Set-ExchangeAutoReply {
+    <#
+    .SYNOPSIS
+        Enables or disables the automatic reply (Out of Office) for a mailbox.
+    .DESCRIPTION
+        Wraps Set-MailboxAutoReplyConfiguration. When enabling, an internal and/or
+        external message may be supplied; supplying an external message also sets the
+        external audience to All. Returns a status string and never surfaces exception
+        detail. Relies on the caller having an active Exchange session.
+    .PARAMETER Mailbox
+        Primary SMTP address or alias of the mailbox.
+    .PARAMETER State
+        Enabled or Disabled.
+    .PARAMETER InternalMessage
+        Auto-reply text shown to internal senders.
+    .PARAMETER ExternalMessage
+        Auto-reply text shown to external senders.
+    .OUTPUTS
+        Status string.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Mailbox,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Enabled', 'Disabled')]
+        [string]$State,
+
+        [string]$InternalMessage,
+
+        [string]$ExternalMessage
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($Mailbox, "Set auto-reply $State")) {
+        return '[!] Skipped by -WhatIf or -Confirm.'
+    }
+
+    try {
+        $params = @{ Identity = $Mailbox; AutoReplyState = $State; ErrorAction = 'Stop' }
+        if ($InternalMessage) { $params.InternalMessage = $InternalMessage }
+        if ($ExternalMessage) {
+            $params.ExternalMessage  = $ExternalMessage
+            $params.ExternalAudience = 'All'
+        }
+        Set-MailboxAutoReplyConfiguration @params | Out-Null
+        return "[OK] Auto-reply $State for $Mailbox"
+    }
+    catch {
+        Write-Warning "Auto-reply update failed: $_"
+        return '[!] Auto-reply update failed. Verify the Exchange connection and mailbox.'
+    }
+}

--- a/LazyWinAdminModule/Private/Set-ExchangeForwarding.ps1
+++ b/LazyWinAdminModule/Private/Set-ExchangeForwarding.ps1
@@ -1,0 +1,50 @@
+function Set-ExchangeForwarding {
+    <#
+    .SYNOPSIS
+        Sets or clears SMTP forwarding on a mailbox.
+    .DESCRIPTION
+        Wraps Set-Mailbox. Pass an empty -ForwardingSmtpAddress to clear forwarding.
+        When forwarding is set, -DeliverToMailboxAndForward controls whether a copy is
+        also kept in the mailbox. Relies on the caller having an active Exchange session.
+    .PARAMETER Mailbox
+        Primary SMTP address or alias of the mailbox.
+    .PARAMETER ForwardingSmtpAddress
+        Destination SMTP address. Empty / whitespace clears forwarding.
+    .PARAMETER DeliverToMailboxAndForward
+        Keep a copy in the mailbox as well as forwarding. Default $true.
+    .OUTPUTS
+        Status string.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Mailbox,
+
+        [string]$ForwardingSmtpAddress,
+
+        [bool]$DeliverToMailboxAndForward = $true
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($Mailbox, 'Set forwarding')) {
+        return '[!] Skipped by -WhatIf or -Confirm.'
+    }
+
+    try {
+        if ([string]::IsNullOrWhiteSpace($ForwardingSmtpAddress)) {
+            Set-Mailbox -Identity $Mailbox -ForwardingSmtpAddress $null -ErrorAction Stop | Out-Null
+            return "[OK] Forwarding cleared for $Mailbox"
+        }
+
+        Set-Mailbox -Identity $Mailbox `
+            -ForwardingSmtpAddress $ForwardingSmtpAddress `
+            -DeliverToMailboxAndForward $DeliverToMailboxAndForward `
+            -ErrorAction Stop | Out-Null
+        return "[OK] Forwarding set to $ForwardingSmtpAddress for $Mailbox"
+    }
+    catch {
+        Write-Warning "Forwarding update failed: $_"
+        return '[!] Forwarding update failed. Verify the Exchange connection and addresses.'
+    }
+}

--- a/LazyWinAdminModule/Tests/EntraUserOffboarding.Tests.ps1
+++ b/LazyWinAdminModule/Tests/EntraUserOffboarding.Tests.ps1
@@ -1,0 +1,141 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Mock stub functions declare params to match real cmdlet signatures.')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseShouldProcessForStateChangingFunctions', '',
+    Justification = 'Stub functions emulate real Graph cmdlet names for mocking; they perform no work.')]
+param()
+
+BeforeAll {
+    $script:ModuleRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Classes') -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Private') -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Public')  -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+
+    if (-not (Get-Command Get-MgContext -ErrorAction SilentlyContinue)) {
+        function Get-MgContext { }
+    }
+    if (-not (Get-Command Update-MgUser -ErrorAction SilentlyContinue)) {
+        function Update-MgUser { param([string]$UserId, [bool]$AccountEnabled) }
+    }
+    if (-not (Get-Command Get-MgUser -ErrorAction SilentlyContinue)) {
+        function Get-MgUser { param([string]$UserId) }
+    }
+}
+
+Describe 'Set-EntraUserAccountState' {
+
+    Context 'Guard - not connected' {
+        BeforeAll { Mock Get-MgContext { $null } }
+        It 'Returns [!] without calling Update-MgUser' {
+            Mock Update-MgUser { }
+            $r = Set-EntraUserAccountState -UserPrincipalName 'u@t.com' -Enabled $false
+            $r | Should -Match '^\[!\]'
+            Should -Invoke Update-MgUser -Times 0
+        }
+    }
+
+    Context 'Block sign-in' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock Update-MgUser { }
+        }
+        It 'Disables the account and reports blocked' {
+            $r = Set-EntraUserAccountState -UserPrincipalName 'u@t.com' -Enabled $false
+            $r | Should -BeLike '*blocked*'
+            Should -Invoke Update-MgUser -Times 1 -Exactly -ParameterFilter { $AccountEnabled -eq $false }
+        }
+    }
+
+    Context 'Enable sign-in' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock Update-MgUser { }
+        }
+        It 'Enables the account and reports enabled' {
+            $r = Set-EntraUserAccountState -UserPrincipalName 'u@t.com' -Enabled $true
+            $r | Should -BeLike '*enabled*'
+            Should -Invoke Update-MgUser -Times 1 -Exactly -ParameterFilter { $AccountEnabled -eq $true }
+        }
+    }
+}
+
+Describe 'Invoke-EntraUserOffboarding' {
+
+    Context 'No steps selected' {
+        It 'Returns a single No-action entry' {
+            $report = @(Invoke-EntraUserOffboarding -UserPrincipalName 'u@t.com')
+            $report.Count      | Should -Be 1
+            $report[0].Result  | Should -BeLike '*No offboarding steps*'
+        }
+    }
+
+    Context 'WhatIf dry run' {
+        BeforeAll { Mock Set-EntraUserAccountState { '[OK] Sign-in blocked for u@t.com' } }
+        It 'Returns a single dry-run line and executes no steps' {
+            $report = @(Invoke-EntraUserOffboarding -UserPrincipalName 'u@t.com' -BlockSignIn -WhatIf)
+            $report.Count   | Should -Be 1
+            $report[0].Step | Should -Be 'Dry run'
+            Should -Invoke Set-EntraUserAccountState -Times 0
+        }
+    }
+
+    Context 'Only selected steps run, in order' {
+        BeforeAll {
+            Mock Set-EntraUserAccountState { '[OK] Sign-in blocked for u@t.com' }
+            Mock Revoke-EntraUserSession  { '[OK] Revoked all sign-in sessions' }
+        }
+        It 'Runs block sign-in then revoke, and nothing else' {
+            $report = @(Invoke-EntraUserOffboarding -UserPrincipalName 'u@t.com' -BlockSignIn -RevokeSessions)
+            $report.Count       | Should -Be 2
+            $report[0].Step     | Should -Be 'Block sign-in'
+            $report[1].Step     | Should -Be 'Revoke sessions'
+            Should -Invoke Set-EntraUserAccountState -Times 1 -Exactly
+            Should -Invoke Revoke-EntraUserSession  -Times 1 -Exactly
+        }
+    }
+
+    Context 'Reset password never leaks the value into the report' {
+        BeforeAll {
+            Mock Set-EntraUserPassword {
+                [PSCustomObject]@{ Status = '[OK] Password reset for u@t.com'; Password = 'S3cretValue!' }
+            }
+        }
+        It 'Records the status but not the password' {
+            $report = @(Invoke-EntraUserOffboarding -UserPrincipalName 'u@t.com' -ResetPassword)
+            $step   = $report | Where-Object { $_.Step -eq 'Reset password' }
+            $step.Result | Should -Match '^\[OK\]'
+            $step.Result | Should -Not -Match 'S3cretValue'
+        }
+    }
+
+    Context 'A failing step is recorded and the rest still run' {
+        BeforeAll {
+            Mock Set-EntraUserAccountState { '[!] Account state update failed.' }
+            Mock Revoke-EntraUserSession  { '[OK] Revoked all sign-in sessions' }
+        }
+        It 'Continues past a failed step' {
+            $report = @(Invoke-EntraUserOffboarding -UserPrincipalName 'u@t.com' -BlockSignIn -RevokeSessions)
+            $report.Count | Should -Be 2
+            ($report | Where-Object { $_.Step -eq 'Block sign-in' }).Result   | Should -Match '\[!\]'
+            ($report | Where-Object { $_.Step -eq 'Revoke sessions' }).Result | Should -Match '\[OK\]'
+        }
+    }
+
+    Context 'Remove from groups resolves object id and removes each membership' {
+        BeforeAll {
+            Mock Get-MgUser { [PSCustomObject]@{ Id = 'user-oid' } }
+            Mock Get-EntraUserMembership { [PSCustomObject]@{ DisplayName = 'Sales'; Id = 'group-1'; Type = 'group' } }
+            Mock Set-EntraGroupMembership { '[OK] Remove membership for user-oid on group group-1' }
+        }
+        It 'Removes the user from the group by object id' {
+            $report = @(Invoke-EntraUserOffboarding -UserPrincipalName 'u@t.com' -RemoveFromGroups)
+            Should -Invoke Set-EntraGroupMembership -Times 1 -Exactly -ParameterFilter {
+                $GroupId -eq 'group-1' -and $UserId -eq 'user-oid' -and $Action -eq 'Remove'
+            }
+            ($report | Where-Object { $_.Step -like 'Remove from group*' }) | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/LazyWinAdminModule/Tests/ExchangeMailboxSettings.Tests.ps1
+++ b/LazyWinAdminModule/Tests/ExchangeMailboxSettings.Tests.ps1
@@ -1,0 +1,101 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Mock stub functions declare params to match real cmdlet signatures.')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseShouldProcessForStateChangingFunctions', '',
+    Justification = 'Stub functions emulate real Exchange cmdlet names for mocking; they perform no work.')]
+param()
+
+BeforeAll {
+    $script:ModuleRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Classes') -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Private') -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Public')  -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+
+    if (-not (Get-Command Set-MailboxAutoReplyConfiguration -ErrorAction SilentlyContinue)) {
+        function Set-MailboxAutoReplyConfiguration { param([string]$Identity, [string]$AutoReplyState, [string]$InternalMessage, [string]$ExternalMessage, [string]$ExternalAudience) }
+    }
+    if (-not (Get-Command Set-Mailbox -ErrorAction SilentlyContinue)) {
+        function Set-Mailbox { param([string]$Identity, $ForwardingSmtpAddress, [bool]$DeliverToMailboxAndForward, [string]$Type) }
+    }
+}
+
+Describe 'Set-ExchangeAutoReply' {
+
+    Context 'WhatIf' {
+        It 'Skips under -WhatIf' {
+            Mock Set-MailboxAutoReplyConfiguration { }
+            Set-ExchangeAutoReply -Mailbox 'm@t.com' -State Enabled -WhatIf | Should -BeLike '*Skipped by -WhatIf*'
+            Should -Invoke Set-MailboxAutoReplyConfiguration -Times 0
+        }
+    }
+
+    Context 'Enable with messages' {
+        BeforeAll { Mock Set-MailboxAutoReplyConfiguration { } }
+        It 'Sets AutoReplyState=Enabled and external audience All when an external message is given' {
+            $r = Set-ExchangeAutoReply -Mailbox 'm@t.com' -State Enabled -InternalMessage 'gone' -ExternalMessage 'away'
+            $r | Should -Match '^\[OK\]'
+            Should -Invoke Set-MailboxAutoReplyConfiguration -Times 1 -Exactly -ParameterFilter {
+                $AutoReplyState -eq 'Enabled' -and $ExternalAudience -eq 'All'
+            }
+        }
+    }
+
+    Context 'Failure' {
+        BeforeAll { Mock Set-MailboxAutoReplyConfiguration { throw 'Exchange connection lost' } }
+        It 'Returns sanitised [!]' {
+            $r = Set-ExchangeAutoReply -Mailbox 'm@t.com' -State Enabled
+            $r | Should -Match '^\[!\]'
+            $r | Should -Not -Match 'connection lost'
+        }
+    }
+}
+
+Describe 'Set-ExchangeForwarding' {
+
+    Context 'Set forwarding' {
+        BeforeAll { Mock Set-Mailbox { } }
+        It 'Passes the forwarding address to Set-Mailbox' {
+            $r = Set-ExchangeForwarding -Mailbox 'm@t.com' -ForwardingSmtpAddress 'boss@t.com'
+            $r | Should -Match '^\[OK\]'
+            Should -Invoke Set-Mailbox -Times 1 -Exactly -ParameterFilter { $ForwardingSmtpAddress -eq 'boss@t.com' }
+        }
+    }
+
+    Context 'Clear forwarding' {
+        BeforeAll { Mock Set-Mailbox { } }
+        It 'Clears forwarding when the address is empty' {
+            $r = Set-ExchangeForwarding -Mailbox 'm@t.com' -ForwardingSmtpAddress ''
+            $r | Should -BeLike '*Forwarding cleared*'
+            Should -Invoke Set-Mailbox -Times 1 -Exactly -ParameterFilter { $null -eq $ForwardingSmtpAddress }
+        }
+    }
+}
+
+Describe 'Convert-ExchangeMailbox' {
+
+    Context 'Convert to shared' {
+        BeforeAll { Mock Set-Mailbox { } }
+        It 'Calls Set-Mailbox -Type Shared' {
+            $r = Convert-ExchangeMailbox -Mailbox 'm@t.com' -Type Shared
+            $r | Should -Match '^\[OK\]'
+            Should -Invoke Set-Mailbox -Times 1 -Exactly -ParameterFilter { $Type -eq 'Shared' }
+        }
+    }
+
+    Context 'WhatIf' {
+        It 'Skips under -WhatIf' {
+            Mock Set-Mailbox { }
+            Convert-ExchangeMailbox -Mailbox 'm@t.com' -Type Shared -WhatIf | Should -BeLike '*Skipped by -WhatIf*'
+            Should -Invoke Set-Mailbox -Times 0
+        }
+    }
+
+    Context 'Rejects an invalid type' {
+        It 'Throws on an out-of-set type' {
+            { Convert-ExchangeMailbox -Mailbox 'm@t.com' -Type 'Bogus' } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
Composes the atomic operations from #38/#39 into the **#1 MSP composite workflow — employee offboarding** — plus the mailbox-settings it needs. Stacked on #39 (retarget to `master` after #38/#39 merge).

## #28 Mailbox settings (Exchange)
| Function | Purpose |
|---|---|
| `Set-ExchangeAutoReply` | Enable/disable Out-of-Office with internal + external text |
| `Set-ExchangeForwarding` | Set or clear SMTP forwarding (keep-a-copy toggle) |
| `Convert-ExchangeMailbox` | Convert user ↔ shared/room/equipment |

## #25 Employee offboarding
- `Set-EntraUserAccountState` — block/enable sign-in (`Update-MgUser -AccountEnabled`).
- `Invoke-EntraUserOffboarding` — runs the leaver checklist by composing the **already-tested** atomic functions. Every step is opt-in via a switch:
  block sign-in → revoke sessions → reset password → convert mailbox to shared → set auto-reply → delegate mailbox to a successor → remove licenses → remove from all groups.

### Design
- **Continue-on-failure**: a failed step is recorded in the returned report; the remaining steps still run.
- **Dry run**: `-WhatIf` returns a single dry-run line without executing anything.
- **No secret leak**: the reset-password step records only its status — never the generated password (test-asserted).
- **Correctness**: group removal resolves the user''s directory object id (`Get-MgUser`) before calling the by-ref remove, since the Graph cmdlet needs the object id, not the UPN.

## Test plan
- [x] **33 mock-based unit tests** — WhatIf, success, sanitised failure, per-step selection, order, continue-on-failure, no-secret-leak, and group-removal id resolution. All pass.
- [x] Integrity + new suites: **126/126, 0 failures** (Integrity confirms all 5 functions load).
- [x] PSScriptAnalyzer clean (Error+Warning, repo settings).
- [ ] Live tenant writes not covered by mocks.

## Remaining
UI wiring still waits on the `Start-LazyWinAdmin` split (#14); onboarding (#26), tenant switcher (#22), MFA report (#29), audit log (#30), coverage gate (#31), and the `.speq` update (#33) remain.

Closes #25
Closes #28