### PR TITLE
feat: employee onboarding wizard (#26)

### DIFF
--- a/LazyWinAdminModule/Private/Invoke-EntraUserOnboarding.ps1
+++ b/LazyWinAdminModule/Private/Invoke-EntraUserOnboarding.ps1
@@ -1,0 +1,71 @@
+function Invoke-EntraUserOnboarding {
+    <#
+    .SYNOPSIS
+        Creates a new user and applies the standard joiner setup. Every step after
+        creation is opt-in.
+    .DESCRIPTION
+        Composes the individually-tested atomic operations: create the account, assign
+        licenses, add to groups, set the manager, and optionally copy mailbox access
+        from a template colleague (so a new hire inherits the same shared-mailbox rights
+        as a peer). A failed step is recorded and does NOT abort the rest. Passing
+        -WhatIf performs a dry run. The one-time password is returned on the result
+        object (for hand-off) and is never placed in any step Result.
+    .OUTPUTS
+        PSCustomObject with UserId (string or $null), Password (string or $null),
+        and Steps (a list of Step/Result records).
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [OutputType([PSCustomObject])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$DisplayName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$UserPrincipalName,
+
+        [string]$MailNickname,
+        [string[]]$AddLicenseSkuId,
+        [string[]]$AddToGroupId,
+        [string]$ManagerId,
+        [string]$CopyAccessFromUpn
+    )
+
+    $steps  = [System.Collections.Generic.List[object]]::new()
+    $record = {
+        param([string]$step, [string]$result)
+        $steps.Add([PSCustomObject]@{ Step = $step; Result = $result })
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($UserPrincipalName, 'Run onboarding workflow')) {
+        & $record 'Dry run' "[!] -WhatIf: would create $UserPrincipalName and apply the selected steps."
+        return [PSCustomObject]@{ UserId = $null; Password = $null; Steps = $steps }
+    }
+
+    $created = New-EntraUser -DisplayName $DisplayName -UserPrincipalName $UserPrincipalName -MailNickname $MailNickname
+    & $record 'Create user' $created.Status
+    if (-not $created.UserId) {
+        return [PSCustomObject]@{ UserId = $null; Password = $null; Steps = $steps }
+    }
+    $userId = $created.UserId
+
+    if ($AddLicenseSkuId) {
+        foreach ($sku in $AddLicenseSkuId) {
+            & $record "Assign license $sku" (Set-EntraUserLicense -UserPrincipalName $UserPrincipalName -AddSkuId $sku)
+        }
+    }
+    if ($AddToGroupId) {
+        foreach ($groupId in $AddToGroupId) {
+            & $record "Add to group $groupId" (Set-EntraGroupMembership -GroupId $groupId -UserId $userId -Action Add)
+        }
+    }
+    if ($ManagerId) {
+        & $record 'Set manager' (Set-EntraUserManager -UserId $userId -ManagerId $ManagerId)
+    }
+    if ($CopyAccessFromUpn) {
+        & $record "Copy access from $CopyAccessFromUpn" (Set-ExchangeMailboxPermission -SourceUser $CopyAccessFromUpn -TargetUser $UserPrincipalName)
+    }
+
+    return [PSCustomObject]@{ UserId = $userId; Password = $created.Password; Steps = $steps }
+}

--- a/LazyWinAdminModule/Private/New-EntraUser.ps1
+++ b/LazyWinAdminModule/Private/New-EntraUser.ps1
@@ -1,0 +1,57 @@
+function New-EntraUser {
+    <#
+    .SYNOPSIS
+        Creates a new Entra ID user with a strong temporary password.
+    .DESCRIPTION
+        Wraps New-MgUser. Generates a random password and forces a change at next
+        sign-in. Requires an active Graph session with User.ReadWrite.All. The
+        temporary password is returned in-memory on the result object for ONE-TIME
+        hand-off to the new hire; it is never logged or placed in the status string.
+    .PARAMETER DisplayName
+        The user's display name.
+    .PARAMETER UserPrincipalName
+        The new UPN (must be an available, verified-domain address).
+    .PARAMETER MailNickname
+        Mail alias. Defaults to the local part of the UPN.
+    .OUTPUTS
+        PSCustomObject with Status (string), Password (string or $null), UserId (string or $null).
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [OutputType([PSCustomObject])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$DisplayName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$UserPrincipalName,
+
+        [string]$MailNickname
+    )
+
+    if ($null -eq (Get-MgContext)) {
+        return [PSCustomObject]@{ Status = '[!] Not connected to Microsoft Graph. Connect on the Cloud tab first.'; Password = $null; UserId = $null }
+    }
+    if (-not $PSCmdlet.ShouldProcess($UserPrincipalName, 'Create user')) {
+        return [PSCustomObject]@{ Status = '[!] Skipped by -WhatIf or -Confirm.'; Password = $null; UserId = $null }
+    }
+
+    try {
+        $nickname    = if ($MailNickname) { $MailNickname } else { ($UserPrincipalName -split '@')[0] }
+        $newPassword = New-LwaSecurePassword -Length 16
+        $body = @{
+            AccountEnabled    = $true
+            DisplayName       = $DisplayName
+            UserPrincipalName = $UserPrincipalName
+            MailNickname      = $nickname
+            PasswordProfile   = @{ Password = $newPassword; ForceChangePasswordNextSignIn = $true }
+        }
+        $user = New-MgUser @body -ErrorAction Stop
+        return [PSCustomObject]@{ Status = "[OK] Created user $UserPrincipalName"; Password = $newPassword; UserId = $user.Id }
+    }
+    catch {
+        Write-Verbose "User creation exception: $_"
+        return [PSCustomObject]@{ Status = '[!] User creation failed. Verify the UPN is available and you hold the required Graph scope.'; Password = $null; UserId = $null }
+    }
+}

--- a/LazyWinAdminModule/Private/Set-EntraUserManager.ps1
+++ b/LazyWinAdminModule/Private/Set-EntraUserManager.ps1
@@ -1,0 +1,44 @@
+function Set-EntraUserManager {
+    <#
+    .SYNOPSIS
+        Sets the manager of an Entra ID user.
+    .DESCRIPTION
+        Wraps Set-MgUserManagerByRef. Requires an active Graph session with
+        User.ReadWrite.All. Both ids are directory object ids.
+    .PARAMETER UserId
+        The user's directory object id.
+    .PARAMETER ManagerId
+        The manager's directory object id.
+    .OUTPUTS
+        Status string.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$UserId,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ManagerId
+    )
+
+    if ($null -eq (Get-MgContext)) {
+        return '[!] Not connected to Microsoft Graph. Connect on the Cloud tab first.'
+    }
+    if (-not $PSCmdlet.ShouldProcess($UserId, 'Set manager')) {
+        return '[!] Skipped by -WhatIf or -Confirm.'
+    }
+
+    try {
+        Set-MgUserManagerByRef -UserId $UserId `
+            -BodyParameter @{ '@odata.id' = "https://graph.microsoft.com/v1.0/users/$ManagerId" } `
+            -ErrorAction Stop | Out-Null
+        return "[OK] Set manager for $UserId"
+    }
+    catch {
+        Write-Verbose "Set manager exception: $_"
+        return '[!] Set manager failed. Verify the ids and your Graph permissions.'
+    }
+}

--- a/LazyWinAdminModule/Tests/EntraUserOnboarding.Tests.ps1
+++ b/LazyWinAdminModule/Tests/EntraUserOnboarding.Tests.ps1
@@ -1,0 +1,152 @@
+#Requires -Version 7.4
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Mock stub functions declare params to match real cmdlet signatures.')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseShouldProcessForStateChangingFunctions', '',
+    Justification = 'Stub functions emulate real Graph cmdlet names for mocking; they perform no work.')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingPlainTextForPassword', '',
+    Justification = 'New-MgUser stub mirrors the real cmdlet signature for mocking; no password is stored or transmitted.')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingUsernameAndPasswordParams', '',
+    Justification = 'New-MgUser stub mirrors the real cmdlet signature for mocking; no credential is handled.')]
+param()
+
+BeforeAll {
+    $script:ModuleRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Classes') -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Private') -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+    Get-ChildItem (Join-Path $script:ModuleRoot 'Public')  -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+
+    if (-not (Get-Command Get-MgContext -ErrorAction SilentlyContinue)) {
+        function Get-MgContext { }
+    }
+    if (-not (Get-Command New-MgUser -ErrorAction SilentlyContinue)) {
+        function New-MgUser { param([bool]$AccountEnabled, [string]$DisplayName, [string]$UserPrincipalName, [string]$MailNickname, $PasswordProfile) }
+    }
+    if (-not (Get-Command Set-MgUserManagerByRef -ErrorAction SilentlyContinue)) {
+        function Set-MgUserManagerByRef { param([string]$UserId, $BodyParameter) }
+    }
+}
+
+Describe 'New-EntraUser' {
+
+    Context 'Guard - not connected' {
+        BeforeAll { Mock Get-MgContext { $null } }
+        It 'Returns [!] status and null ids without calling New-MgUser' {
+            Mock New-MgUser { }
+            $r = New-EntraUser -DisplayName 'Jane Doe' -UserPrincipalName 'jane@t.com'
+            $r.Status | Should -Match '^\[!\]'
+            $r.UserId | Should -BeNullOrEmpty
+            Should -Invoke New-MgUser -Times 0
+        }
+    }
+
+    Context 'Success' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock New-MgUser { [PSCustomObject]@{ Id = 'new-oid' } }
+        }
+        It 'Creates the user, forces password change, returns id + password' {
+            $r = New-EntraUser -DisplayName 'Jane Doe' -UserPrincipalName 'jane@t.com'
+            $r.Status   | Should -Match '^\[OK\]'
+            $r.UserId   | Should -Be 'new-oid'
+            $r.Password | Should -Not -BeNullOrEmpty
+            Should -Invoke New-MgUser -Times 1 -Exactly -ParameterFilter {
+                $UserPrincipalName -eq 'jane@t.com' -and $PasswordProfile.ForceChangePasswordNextSignIn -eq $true
+            }
+        }
+        It 'Never puts the password into the status string' {
+            $r = New-EntraUser -DisplayName 'Jane Doe' -UserPrincipalName 'jane@t.com'
+            $r.Status | Should -Not -BeLike "*$($r.Password)*"
+        }
+    }
+
+    Context 'Failure' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock New-MgUser { throw 'A user with this UPN already exists' }
+        }
+        It 'Returns sanitised [!] and null ids' {
+            $r = New-EntraUser -DisplayName 'Jane Doe' -UserPrincipalName 'jane@t.com'
+            $r.Status | Should -Match '^\[!\]'
+            $r.Status | Should -Not -Match 'already exists'
+            $r.UserId | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Set-EntraUserManager' {
+
+    Context 'Guard - not connected' {
+        BeforeAll { Mock Get-MgContext { $null } }
+        It 'Returns [!] without calling the cmdlet' {
+            Mock Set-MgUserManagerByRef { }
+            (Set-EntraUserManager -UserId 'u' -ManagerId 'm') | Should -Match '^\[!\]'
+            Should -Invoke Set-MgUserManagerByRef -Times 0
+        }
+    }
+
+    Context 'Success' {
+        BeforeAll {
+            Mock Get-MgContext { [PSCustomObject]@{ TenantId = 't' } }
+            Mock Set-MgUserManagerByRef { }
+        }
+        It 'References the manager object id in the odata body' {
+            $r = Set-EntraUserManager -UserId 'user-oid' -ManagerId 'mgr-oid'
+            $r | Should -Match '^\[OK\]'
+            Should -Invoke Set-MgUserManagerByRef -Times 1 -Exactly -ParameterFilter {
+                $UserId -eq 'user-oid' -and $BodyParameter['@odata.id'] -like '*mgr-oid'
+            }
+        }
+    }
+}
+
+Describe 'Invoke-EntraUserOnboarding' {
+
+    Context 'WhatIf dry run' {
+        BeforeAll { Mock New-EntraUser { [PSCustomObject]@{ Status = '[OK]'; Password = 'x'; UserId = 'oid' } } }
+        It 'Returns a dry-run step and creates nothing' {
+            $r = Invoke-EntraUserOnboarding -DisplayName 'Jane' -UserPrincipalName 'jane@t.com' -WhatIf
+            @($r.Steps)[0].Step | Should -Be 'Dry run'
+            $r.UserId | Should -BeNullOrEmpty
+            Should -Invoke New-EntraUser -Times 0
+        }
+    }
+
+    Context 'Creation fails - workflow stops' {
+        BeforeAll {
+            Mock New-EntraUser { [PSCustomObject]@{ Status = '[!] User creation failed.'; Password = $null; UserId = $null } }
+            Mock Set-EntraUserLicense { '[OK]' }
+        }
+        It 'Records the failure and runs no further steps' {
+            $r = Invoke-EntraUserOnboarding -DisplayName 'Jane' -UserPrincipalName 'jane@t.com' -AddLicenseSkuId 'sku-1'
+            $r.UserId | Should -BeNullOrEmpty
+            @($r.Steps).Count | Should -Be 1
+            Should -Invoke Set-EntraUserLicense -Times 0
+        }
+    }
+
+    Context 'Full onboarding' {
+        BeforeAll {
+            Mock New-EntraUser { [PSCustomObject]@{ Status = '[OK] Created user jane@t.com'; Password = 'TempP@ss123'; UserId = 'new-oid' } }
+            Mock Set-EntraUserLicense { '[OK] Updated licenses' }
+            Mock Set-EntraGroupMembership { '[OK] Add membership' }
+            Mock Set-EntraUserManager { '[OK] Set manager' }
+            Mock Set-ExchangeMailboxPermission { '[OK] Mirrored permissions' }
+        }
+        It 'Applies license, group, manager and copy-access, returns password on the result only' {
+            $r = Invoke-EntraUserOnboarding -DisplayName 'Jane' -UserPrincipalName 'jane@t.com' `
+                    -AddLicenseSkuId 'sku-1' -AddToGroupId 'group-1' -ManagerId 'mgr-oid' -CopyAccessFromUpn 'peer@t.com'
+            $r.UserId   | Should -Be 'new-oid'
+            $r.Password | Should -Be 'TempP@ss123'
+            Should -Invoke Set-EntraGroupMembership -Times 1 -Exactly -ParameterFilter { $UserId -eq 'new-oid' -and $Action -eq 'Add' }
+            Should -Invoke Set-EntraUserManager     -Times 1 -Exactly
+            Should -Invoke Set-ExchangeMailboxPermission -Times 1 -Exactly -ParameterFilter { $SourceUser -eq 'peer@t.com' -and $TargetUser -eq 'jane@t.com' }
+            # Password must not appear in any step result
+            ($r.Steps | Where-Object { $_.Result -like '*TempP@ss123*' }) | Should -BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
The joiner counterpart to the offboarding workflow (#25) — completes the full user lifecycle from the same tested building blocks. Stacked on #40.

## New functions
| Function | Purpose | Graph cmdlet |
|---|---|---|
| `New-EntraUser` | Create a user with a strong temp password, force change at next sign-in | `New-MgUser` |
| `Set-EntraUserManager` | Set the user''s manager | `Set-MgUserManagerByRef` |
| `Invoke-EntraUserOnboarding` | Create + apply joiner setup (licenses, groups, manager, copy-access-from-template) | composes the atomic ops |

## Design
- **Copy access from a template colleague**: a new hire in a role inherits the same shared-mailbox rights as a peer via the existing Mirror (`Set-ExchangeMailboxPermission -SourceUser <peer> -TargetUser <newhire>`).
- **Continue-on-failure** + **`-WhatIf` dry run**, same as offboarding.
- **One-time password**: returned on the result object (`.Password`) for hand-off to the new hire; **never** placed in any step Result (test-asserted).
- Creation failure stops the workflow (no point licensing a user that wasn''t created).

## Test plan
- [x] **12 mock-based unit tests** — guards, WhatIf, success, sanitised failure, stop-on-create-failure, full onboarding, no-secret-leak. All pass.
- [x] Integrity + suite: **118/118, 0 failures**.
- [x] PSScriptAnalyzer clean.

## Remaining roadmap
UI wiring (gated on the `Start-LazyWinAdmin` split #14), tenant switcher (#22), MFA report (#29), audit log (#30), coverage gate (#31), `.speq` update (#33).

Closes #26